### PR TITLE
fix: add alpine dependencies for pg driver

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,0 +1,44 @@
+name: Build containers CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  REGISTRY: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/scan-websites
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.filter.outputs.changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            api: 'api/**'
+
+  build-push-and-deploy:
+    runs-on: ubuntu-latest
+    needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJSON(needs.changes.outputs.images) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build container
+        working-directory: ./${{ matrix.image }}
+        run: |
+          docker build \
+          --build-arg git_sha=$GITHUB_SHA \
+          -t $REGISTRY/${{ matrix.image }}:$GITHUB_SHA \
+          -t $REGISTRY/${{ matrix.image }}:latest .

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -23,7 +23,11 @@ RUN apk add --no-cache \
     libexecinfo-dev \
     make \
     cmake \
-    libcurl
+    libcurl \
+    postgresql-dev \
+    gcc \
+    python3-dev \
+    musl-dev
 
 # Include global args in this stage of the build
 ARG FUNCTION_DIR


### PR DESCRIPTION
Currently our alpine optimized image of the API is missing the ability to compile the driver for postgres. 