### PR TITLE
fix: tune lambda

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -4,9 +4,9 @@ resource "aws_lambda_function" "api" {
   package_type = "Image"
   image_uri    = "${aws_ecr_repository.api.repository_url}:latest"
 
-  timeout = 900
+  timeout = 60
 
-  memory_size = 512
+  memory_size = 1024
 
   environment {
     variables = {


### PR DESCRIPTION
Tunes the lambda to exit after 60 seconds and increases the memory available
