### PR TITLE
fix: fix issues with rds and default nacl

### DIFF
--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source                  = "github.com/cds-snc/terraform-modules?ref=v0.0.10//rds"
+  source                  = "github.com/cds-snc/terraform-modules?ref=v0.0.11//rds"
   backup_retention_period = 1
   billing_tag_value       = var.billing_code
   database_name           = "scan_websites"
@@ -11,4 +11,5 @@ module "rds" {
   username                = var.rds_username
   password                = var.rds_password
   vpc_id                  = module.vpc.vpc_id
+  engine_version          = "11.9"
 }

--- a/terragrunt/aws/api/vpc.tf
+++ b/terragrunt/aws/api/vpc.tf
@@ -1,5 +1,5 @@
 module "vpc" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v0.0.5//vpc"
+  source            = "github.com/cds-snc/terraform-modules?ref=v0.0.11//vpc"
   name              = var.product_name
   billing_tag_value = var.billing_code
   high_availability = true


### PR DESCRIPTION
# Summary | Résumé

Adds a nacl so the default nacl doesn't keep acquiring the subnets
Adds an engine version to instance which should fix issue of not being
able to find postgresql error
