### PR TITLE
Fixup zsh in devcontainer.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ ARG TERRAGRUNT_CHECKSUM
 # Install packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends awscli ca-certificates curl git gnupg2 jq make openssh-client python3-pip vim xz-utils zsh \
-    && apt-get autoremove -y && apt-get clean -y 
+    && apt-get autoremove -y && apt-get clean -y
 
 # Install Terraform
 RUN curl -Lo terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
@@ -36,7 +36,7 @@ RUN curl -Lo terragrunt https://github.com/gruntwork-io/terragrunt/releases/down
     && mv terragrunt /usr/local/bin/
 
 # Install ShellCheck
-RUN curl -Lo shellcheck.tar.xz "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \ 
+RUN curl -Lo shellcheck.tar.xz "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
     && echo "${SHELLCHECK_CHECKSUM} shellcheck.tar.xz" | sha256sum --check \
     && tar -xf shellcheck.tar.xz \
     && mv "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/ \
@@ -53,7 +53,7 @@ complete -C /usr/local/bin/terraform terraform\n\
 complete -C /usr/local/bin/terraform terragrunt\n\
 alias tf='terraform'\n\
 alias tg='terragrunt'\n\
-alias ll='la -la'" >> /home/"${USERNAME}"/.zshrc
+alias ll='la -la'" >> /home/vscode/.zshrc
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 	"workspaceFolder": "/workspace",
 
 	// Set *default* container specific settings.json values on container create.
-	"settings": { 
+	"settings": {
 		"python.pythonPath": "/usr/local/bin/python",
 		"python.languageServer": "Pylance",
 		"python.linting.enabled": true,
@@ -20,7 +20,9 @@
 		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
 		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
 		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+
+		"terminal.integrated.shell.linux": "/bin/zsh"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
@@ -35,6 +37,5 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "pip3 install --user -r api/requirements.txt && pip3 install --user -r api/requirements_dev.txt",
 
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }


### PR DESCRIPTION
# Summary | Résumé

This PR fixes the creation of the zshrc file so it correctly goes to the
/home/vscode/.zshrc file instead of /home/.zshrc. It also configures
VSCode to use zsh in the devcontainer by default instead of bash.
