### PR TITLE
Use targets instead of for loop in top level makefile.

### DIFF
--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -16,8 +16,6 @@ jobs:
           api:
             - Makefile
             - 'api/**'
-          scanners/axe-core:
-            - Makefile
             - 'scanners/axe-core/**'
 
   python-tests:

--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -13,8 +13,12 @@ jobs:
       id: filter
       with:
         filters: |
-          api: 'api/**'
-          scanners/axe-core: 'scanners/axe-core/**'
+          api:
+            - Makefile
+            - 'api/**'
+          scanners/axe-core:
+            - Makefile
+            - 'scanners/axe-core/**'
 
   python-tests:
     runs-on: ubuntu-latest

--- a/api/main.py
+++ b/api/main.py
@@ -16,7 +16,7 @@ def handler(event, context):
         response = asgi_handler(event, context)
         return response
 
-    elif event.get("task","") == "migrate":
+    elif event.get("task", "") == "migrate":
         try:
             migrate_head()
             return "Success"

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -19,12 +19,12 @@ def test_handler_unmatched_event(mock_logger):
 
 @patch("main.migrate_head")
 def test_handler_migrate_event(mock_migrate_head):
-    assert main.handler({"task" : "migrate"}, {}) == "Success"
+    assert main.handler({"task": "migrate"}, {}) == "Success"
     mock_migrate_head.assert_called_once()
 
 
 @patch("main.migrate_head")
 def test_handler_migrate_event_failed(mock_migrate_head):
     mock_migrate_head.side_effect = Exception()
-    assert main.handler({"task" : "migrate"}, {}) == "Error"
+    assert main.handler({"task": "migrate"}, {}) == "Error"
     mock_migrate_head.assert_called_once()

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -16,13 +16,15 @@ def test_handler_unmatched_event(mock_logger):
     assert main.handler({}, {}) is False
     mock_logger.warning.assert_called_once_with("Handler recieved unrecognised event")
 
+
 @patch("main.migrate_head")
 def test_handler_migrate_event(mock_migrate_head):
-    assert main.handler({ "task" : "migrate"}, {})  == "Success"
+    assert main.handler({"task" : "migrate"}, {}) == "Success"
     mock_migrate_head.assert_called_once()
+
 
 @patch("main.migrate_head")
 def test_handler_migrate_event_failed(mock_migrate_head):
     mock_migrate_head.side_effect = Exception()
-    assert main.handler({ "task" : "migrate"}, {})  == "Error"
+    assert main.handler({"task" : "migrate"}, {}) == "Error"
     mock_migrate_head.assert_called_once()

--- a/scanners/axe-core/src/common/foreach.ts
+++ b/scanners/axe-core/src/common/foreach.ts
@@ -1,7 +1,7 @@
 // Helper function to run asynchronous foreach loop.
 export async function asyncForEach<T>(
   array: T[],
-  callback: (item: T, idx: number, ary: T[]) => void,
+  callback: (item: T, idx: number, ary: T[]) => void
 ): Promise<void> {
   for (let index = 0; index < array.length; index++) {
     await callback(array[parseInt(`${index}`)], index, array);

--- a/scanners/axe-core/src/impl.test.ts
+++ b/scanners/axe-core/src/impl.test.ts
@@ -86,7 +86,7 @@ describe("Impl", () => {
         browser,
         storeMock,
         "databucketName",
-        "screenshotBucketName",
+        "screenshotBucketName"
       );
 
       expect(storeMock.putObject).toHaveBeenCalledWith({
@@ -124,7 +124,7 @@ describe("Impl", () => {
       browser,
       storeMock,
       "databucketName",
-      "screenshotBucketName",
+      "screenshotBucketName"
     );
     expect(storeMock.putObject).toHaveBeenCalledWith({
       Bucket: "databucketName",

--- a/scanners/axe-core/src/impl.ts
+++ b/scanners/axe-core/src/impl.ts
@@ -12,7 +12,7 @@ export async function Impl(
   browser: Browser,
   store: BlobStore,
   reportBucket: string,
-  screenshotBucket: string,
+  screenshotBucket: string
 ): Promise<boolean> {
   try {
     await asyncForEach(records, async (record: Record) => {
@@ -50,7 +50,7 @@ export async function Impl(
 export async function convertEventToRecords(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   event: any,
-  store: BlobStore,
+  store: BlobStore
 ): Promise<Record[]> {
   const records: Record[] = [];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -95,7 +95,7 @@ const createReport = async (
   url: string,
   page: Page,
   payload: Payload,
-  reportBucket: string,
+  reportBucket: string
 ) => {
   if (isStringEmptyUndefinedOrNull(reportBucket)) {
     return;
@@ -129,7 +129,7 @@ const takeScreenshot = async (
   store: BlobStore,
   key: string,
   page: Page,
-  screenshotBucket: string,
+  screenshotBucket: string
 ) => {
   if (isStringEmptyUndefinedOrNull(screenshotBucket)) {
     return;


### PR DESCRIPTION
# Summary | Résumé

This PR updates the top level makefile to generate targets for each of
the [resource, command] pairs. The commands then invoke the relevant
targets for each resources. This allows make to correctly handle an error
in one of the targets and exit.

Fixes #45
