### PR TITLE
feat: add S3 bucket for axe core reports and SNS queue for axe-core-urls

### DIFF
--- a/terragrunt/aws/api/kms.tf
+++ b/terragrunt/aws/api/kms.tf
@@ -1,4 +1,4 @@
-  
+
 data "aws_caller_identity" "current" {}
 
 resource "aws_kms_key" "scan-websites" {

--- a/terragrunt/aws/api/kms.tf
+++ b/terragrunt/aws/api/kms.tf
@@ -1,0 +1,53 @@
+  
+data "aws_caller_identity" "current" {}
+
+resource "aws_kms_key" "scan-websites" {
+  description         = "KMS Key"
+  enable_key_rotation = true
+
+  policy = <<EOF
+{
+  "Version" : "2012-10-17",
+  "Id" : "key-default-1",
+  "Statement" : [ {
+      "Sid" : "Enable IAM User Permissions",
+      "Effect" : "Allow",
+      "Principal" : {
+        "AWS" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      },
+      "Action" : "kms:*",
+      "Resource" : "*"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": { "Service": "logs.ca-central-1.amazonaws.com" },
+      "Action": [ 
+        "kms:Encrypt*",
+        "kms:Decrypt*",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:Describe*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "Allow_CloudWatch_for_CMK",
+      "Effect": "Allow",
+      "Principal": {
+          "Service":[
+              "cloudwatch.amazonaws.com"
+          ]
+      },
+      "Action": [
+          "kms:Decrypt","kms:GenerateDataKey"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+
+  tags = {
+    CostCenter = var.billing_code
+  }
+}

--- a/terragrunt/aws/api/s3.tf
+++ b/terragrunt/aws/api/s3.tf
@@ -1,0 +1,14 @@
+resource "aws_s3_bucket" "axe-core-report-data" {
+  bucket = "${var.product_name}-${var.env}-axe-core-report-data"
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  tags = {
+    CostCenter = var.billing_code
+  }
+}

--- a/terragrunt/aws/api/sns.tf
+++ b/terragrunt/aws/api/sns.tf
@@ -1,6 +1,6 @@
 resource "aws_sns_topic" "axe-core-urls" {
   name              = "axe-core-urls"
-  kms_master_key_id = aws_kms_key.a11y-tools.arn
+  kms_master_key_id = aws_kms_key.scan-websites.arn
 
   tags = {
     CostCenter = var.billing_code

--- a/terragrunt/aws/api/sns.tf
+++ b/terragrunt/aws/api/sns.tf
@@ -1,0 +1,8 @@
+resource "aws_sns_topic" "axe-core-urls" {
+  name              = "axe-core-urls"
+  kms_master_key_id = aws_kms_key.a11y-tools.arn
+
+  tags = {
+    CostCenter = var.billing_code
+  }
+}


### PR DESCRIPTION
This PR adds an S3 bucket to the infrastructure to collect axe-core reports. It also adds a SNS topic that will send URLs to be scanned by axe-core.