### PR TITLE
feat: add api to docker compose network

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,9 @@
 version: '3'
 
+x-db-connection-strings: &db-connection-strings
+  SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@db/scan-websites
+  SQLALCHEMY_DATABASE_TEST_URI: postgresql://postgres:postgres@test-db/scan-websites
+
 services:
   app:
     build: 
@@ -18,15 +22,13 @@ services:
     volumes:
       - ..:/workspace:cached   
     command: sleep infinity
-    ports: 
-      - 8000:8000
-    links: 
-      - db
-      - test-db
-    environment: 
-      SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@db/scan-websites
-      SQLALCHEMY_DATABASE_TEST_URI: postgresql://postgres:postgres@test-db/scan-websites
-
+    environment:
+      <<: *db-connection-strings
+  api:
+    build:
+      context: ../api/
+    environment:
+      <<: *db-connection-strings
   db:
     image: postgres:11.2
     volumes:

--- a/.github/workflows/scripts/run_shellcheck.sh
+++ b/.github/workflows/scripts/run_shellcheck.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:v0.7.1 -P ./bin/ -x ./.github/workflows/scripts/*.sh
+docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:v0.7.2 -P ./bin/ -x ./.github/workflows/scripts/*.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,17 @@
+name: Shellcheck
+on:
+  push:
+    paths:
+      - "**/*.sh"
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Shellcheck
+      run: |
+        .github/workflows/scripts/run-shellcheck.sh
+
+
+

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Shellcheck
       run: |
-        .github/workflows/scripts/run-shellcheck.sh
+        .github/workflows/scripts/run_shellcheck.sh
 
 
 

--- a/.github/workflows/tf_apply.yml
+++ b/.github/workflows/tf_apply.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Setup Terragrunt
         run: |
-          mkdir bin
+          mkdir -p bin
           wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/$TERRAGRUNT_VERSION/terragrunt_linux_amd64
           chmod +x bin/terragrunt
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH

--- a/.github/workflows/tf_plan.yml
+++ b/.github/workflows/tf_plan.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Setup Terragrunt
         run: |
-          mkdir bin
+          mkdir -p bin
           wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/$TERRAGRUNT_VERSION/terragrunt_linux_amd64
           chmod +x bin/*
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -65,8 +65,6 @@ ENV GIT_SHA=$git_sha
 
 # Install lambda runtime interactive environment
 ARG RIE_VERSION=1.1
-# RUN wget https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie \
-#     && mv aws-lambda-rie /usr/bin/aws-lambda-rie
 RUN wget -O aws-lambda-rie https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/download/${RIE_VERSION}/aws-lambda-rie \
     && mv aws-lambda-rie /usr/bin/aws-lambda-rie
 COPY bin/entry.sh /

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -63,8 +63,12 @@ COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}
 ARG git_sha 
 ENV GIT_SHA=$git_sha
 
-# (Optional) Add Lambda Runtime Interface Emulator and use a script in the ENTRYPOINT for simpler local runs
-ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie /usr/bin/aws-lambda-rie
+# Install lambda runtime interactive environment
+ARG RIE_VERSION=1.1
+# RUN wget https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie \
+#     && mv aws-lambda-rie /usr/bin/aws-lambda-rie
+RUN wget -O aws-lambda-rie https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/download/${RIE_VERSION}/aws-lambda-rie \
+    && mv aws-lambda-rie /usr/bin/aws-lambda-rie
 COPY bin/entry.sh /
 RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh
 

--- a/api/main.py
+++ b/api/main.py
@@ -2,12 +2,15 @@ from mangum import Mangum
 from api_gateway import api
 from logger import log
 from database.migrate import migrate_head
-
+import os
 
 app = api.app
-
+def print_env_variables():
+    rapi = os.getenv("AWS_LAMBDA_RUNTIME_API", "NOT_FOUND")
+    log.info(f"AWS_LAMBDA_RUNTIME_API: {rapi}")
 
 def handler(event, context):
+    print_env_variables()
     # TODO: handle different events other than https
     if "httpMethod" in event:
         # Assume it is an API Gateway event

--- a/api/main.py
+++ b/api/main.py
@@ -5,9 +5,12 @@ from database.migrate import migrate_head
 import os
 
 app = api.app
+
+
 def print_env_variables():
     rapi = os.getenv("AWS_LAMBDA_RUNTIME_API", "NOT_FOUND")
     log.info(f"AWS_LAMBDA_RUNTIME_API: {rapi}")
+
 
 def handler(event, context):
     print_env_variables()

--- a/bin/api_healthcheck.sh
+++ b/bin/api_healthcheck.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo hitting api healthcheck endpoint
+curl "http://api:8080/2015-03-31/functions/function/invocations" -d '{
+    "resource": "/",
+    "path": "/healthcheck",
+    "requestContext": {},
+    "httpMethod": "GET",
+    "headers": {},
+    "multiValueHeaders": { },
+    "queryStringParameters": null,
+    "multiValueQueryStringParameters": null,
+    "pathParameters": null,
+    "stageVariables": null,
+    "body": null,
+    "isBase64Encoded": false
+}' |jq

--- a/bin/api_migrate.sh
+++ b/bin/api_migrate.sh
@@ -1,0 +1,6 @@
+#!/bin/bash 
+
+echo hitting api version endpoint
+curl "http://api:8080/2015-03-31/functions/function/invocations" -d '{
+  "task": "migrate"
+}' |jq

--- a/bin/api_version.sh
+++ b/bin/api_version.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo hitting api version endpoint
+curl "http://api:8080/2015-03-31/functions/function/invocations" -d '{
+    "resource": "/",
+    "path": "/version",
+    "requestContext": {},
+    "httpMethod": "GET",
+    "headers": {},
+    "multiValueHeaders": { },
+    "queryStringParameters": null,
+    "multiValueQueryStringParameters": null,
+    "pathParameters": null,
+    "stageVariables": null,
+    "body": null,
+    "isBase64Encoded": false
+}' |jq

--- a/scanners/axe-core/Dockerfile
+++ b/scanners/axe-core/Dockerfile
@@ -78,7 +78,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 # (Optional) Add Lambda Runtime Interface Emulator and use a script in the ENTRYPOINT for simpler local runs
 # Install lambda runtime interactive environment
 ARG RIE_VERSION=1.1
-RUN curl -Lo aws-lambda-rie https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/download/${RIE_VERSION}/aws-lambda-rie \
+RUN wget -O aws-lambda-rie https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/download/${RIE_VERSION}/aws-lambda-rie \
     && mv aws-lambda-rie /usr/bin/aws-lambda-rie
 COPY bin/entry.sh /
 RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh

--- a/scanners/axe-core/Dockerfile
+++ b/scanners/axe-core/Dockerfile
@@ -76,7 +76,9 @@ ENV GIT_SHA=$git_sha
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # (Optional) Add Lambda Runtime Interface Emulator and use a script in the ENTRYPOINT for simpler local runs
-ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie /usr/bin/aws-lambda-rie
+# Install lambda runtime interactive environment
+RUN curl -Lo aws-lambda-rie https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/download/${RIE_VERSION}/aws-lambda-rie \
+    && mv aws-lambda-rie /usr/bin/aws-lambda-rie
 COPY bin/entry.sh /
 RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh
 

--- a/scanners/axe-core/Dockerfile
+++ b/scanners/axe-core/Dockerfile
@@ -77,6 +77,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # (Optional) Add Lambda Runtime Interface Emulator and use a script in the ENTRYPOINT for simpler local runs
 # Install lambda runtime interactive environment
+ARG RIE_VERSION=1.1
 RUN curl -Lo aws-lambda-rie https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/download/${RIE_VERSION}/aws-lambda-rie \
     && mv aws-lambda-rie /usr/bin/aws-lambda-rie
 COPY bin/entry.sh /


### PR DESCRIPTION
# Summary | Résumé

- clean up the docker compose file
- add scripts to execute the lambda endpoints in the api service
- download a pinned version of the aws-lambda-rie Executable
- add some logging of env variables to the api
- add shellcheck as a ci check

