### PR TITLE
feat: add axe-core scanner lambda

### DIFF
--- a/terragrunt/aws/api/outputs.tf
+++ b/terragrunt/aws/api/outputs.tf
@@ -2,6 +2,10 @@ output "axe_core_report_data_bucket_id" {
   value = aws_s3_bucket.axe-core-report-data.id
 }
 
+output "axe_core_screenshots_bucket_id" {
+  value = aws_s3_bucket.axe-core-screenshots.id
+}
+
 output "axe_core_urls_topic_arn" {
   value = aws_sns_topic.axe-core-urls.arn
 }

--- a/terragrunt/aws/api/s3.tf
+++ b/terragrunt/aws/api/s3.tf
@@ -12,3 +12,19 @@ resource "aws_s3_bucket" "axe-core-report-data" {
     CostCenter = var.billing_code
   }
 }
+
+resource "aws_s3_bucket" "axe-core-screenshots" {
+  bucket = "${var.product_name}-${var.env}-axe-core-screenshots"
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  tags = {
+    CostCenter = var.billing_code
+  }
+}
+

--- a/terragrunt/aws/scanners/axe-core/iam.tf
+++ b/terragrunt/aws/scanners/axe-core/iam.tf
@@ -1,0 +1,85 @@
+data "aws_iam_policy_document" "service_principal" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "scanners-axe-core" {
+  name               = "${var.product_name}-scanners-axe-core"
+  assume_role_policy = data.aws_iam_policy_document.service_principal.json
+}
+
+data "aws_iam_policy" "lambda_insights" {
+  name = "CloudWatchLambdaInsightsExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_insights" {
+  role       = aws_iam_role.scanners-axe-core.name
+  policy_arn = data.aws_iam_policy.lambda_insights.arn
+}
+
+data "aws_iam_policy_document" "api_policies" {
+
+  statement {
+
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
+
+  statement {
+
+    effect = "Allow"
+
+    actions = [
+      "ecr:GetDownloadUrlForlayer",
+      "ecr:BatchGetImage"
+    ]
+    resources = [
+      aws_ecr_repository.scanners-axe-core.arn
+    ]
+  }
+
+  statement {
+
+    effect = "Allow"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:ListBucketVersions",
+      "s3:GetBucketLocation",
+      "s3:Get*",
+      "s3:Put*"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+
+}
+
+resource "aws_iam_policy" "scanners-axe-core" {
+  name   = "${var.product_name}-scanners-axe-core"
+  path   = "/"
+  policy = data.aws_iam_policy_document.api_policies.json
+}
+
+resource "aws_iam_role_policy_attachment" "scanners-axe-core" {
+  role       = aws_iam_role.scanners-axe-core.name
+  policy_arn = aws_iam_policy.scanners-axe-core.arn
+}

--- a/terragrunt/aws/scanners/axe-core/inputs.tf
+++ b/terragrunt/aws/scanners/axe-core/inputs.tf
@@ -2,6 +2,10 @@ variable "axe_core_report_data_bucket_id" {
   type = string
 }
 
+variable "axe_core_screenshots_bucket_id" {
+  type = string
+}
+
 variable "axe_core_urls_topic_arn" {
   type = string
 }

--- a/terragrunt/aws/scanners/axe-core/lambda.tf
+++ b/terragrunt/aws/scanners/axe-core/lambda.tf
@@ -1,0 +1,37 @@
+resource "aws_lambda_function" "scanners-axe-core" {
+  function_name = "scanners-axe-core"
+
+  package_type = "Image"
+  image_uri    = "${aws_ecr_repository.scanners-axe-core.repository_url}:latest"
+
+  role    = aws_iam_role.scanners-axe-core.arn
+  timeout = 60
+
+  memory_size = 1600
+
+  environment {
+    variables = {
+      REPORT_DATA_BUCKET = var.axe_core_report_data_bucket_id
+      SCREENSHOT_BUCKET  = var.axe_core_screenshots_bucket_id
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      image_uri,
+    ]
+  }
+}
+
+resource "aws_sns_topic_subscription" "scanners-axe-core-lambda-subscription" {
+  topic_arn = var.axe_core_urls_topic_arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.scanners-axe-core.arn
+}
+
+resource "aws_lambda_permission" "scanners-axe-core-lambda-permission" {
+  function_name = aws_lambda_function.scanners-axe-core.function_name
+  action        = "lambda:InvokeFunction"
+  principal     = "sns.amazonaws.com"
+  source_arn    = var.axe_core_urls_topic_arn
+}

--- a/terragrunt/env/scanners/axe-core/terragrunt.hcl
+++ b/terragrunt/env/scanners/axe-core/terragrunt.hcl
@@ -12,12 +12,14 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
   mock_outputs = {
     axe_core_report_data_bucket_id = ""
+    axe_core_screenshots_bucket_id = ""
     axe_core_urls_topic_arn        = ""
   }
 }
 
 inputs = {
   axe_core_report_data_bucket_id = dependency.api.outputs.axe_core_report_data_bucket_id
+  axe_core_screenshots_bucket_id = dependency.api.outputs.axe_core_screenshots_bucket_id
   axe_core_urls_topic_arn        = dependency.api.outputs.axe_core_urls_topic_arn
 }
 


### PR DESCRIPTION
Adds the lambda to the axe-core scanner. The lambda is triggered through messages in an SNS queue and will write reports to an S3 bucket and also take a screenshot of the URL it visits.