### PR TITLE
feat: adds the S3 report trigger to the API and adds sample handling

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -27,6 +27,8 @@ def handler(event, context):
         for record in event.get("Records", []):
             if "s3" in record:
                 storage.get_object(record)
+            else:
+                log.warning(f"Handler recieved unrecognised record: {record}")
         return "Success"
 
     elif event.get("task", "") == "migrate":

--- a/api/main.py
+++ b/api/main.py
@@ -2,6 +2,7 @@ from mangum import Mangum
 from api_gateway import api
 from logger import log
 from database.migrate import migrate_head
+from storage import storage
 import os
 
 app = api.app
@@ -21,6 +22,12 @@ def handler(event, context):
         asgi_handler = Mangum(app)
         response = asgi_handler(event, context)
         return response
+
+    elif "Records" in event:
+        for record in event.get("Records", []):
+            if "s3" in record:
+                storage.get_object(record)
+        return "Success"
 
     elif event.get("task", "") == "migrate":
         try:

--- a/api/main.py
+++ b/api/main.py
@@ -28,7 +28,7 @@ def handler(event, context):
             if "s3" in record:
                 storage.get_object(record)
             else:
-                log.warning(f"Handler recieved unrecognised record: {record}")
+                log.warning(f"Handler received unrecognised record: {record}")
         return "Success"
 
     elif event.get("task", "") == "migrate":
@@ -40,6 +40,6 @@ def handler(event, context):
             return "Error"
 
     else:
-        log.warning("Handler recieved unrecognised event")
+        log.warning("Handler received unrecognised event")
 
     return False

--- a/api/storage/storage.py
+++ b/api/storage/storage.py
@@ -1,0 +1,21 @@
+import boto3
+from logger import log
+
+
+def get_object(record):
+    client = boto3.resource("s3")
+    obj = client.Object(record.s3.bucket.name, record.s3.object.key)
+    try:
+        body = obj.get()["Body"].read()
+
+        # Do something with the data here. Ex. Put in DB for querying
+
+        log.info(
+            f"Downloaded {record.s3.object.key} from {record.s3.bucket.name} with length {len(body)}"
+        )
+        return True
+    except Exception:
+        log.error(
+            f"Error downloading {record.s3.object.key} from {record.s3.bucket.name}"
+        )
+        return False

--- a/api/storage/storage.py
+++ b/api/storage/storage.py
@@ -7,13 +7,10 @@ def get_object(record):
     obj = client.Object(record.s3.bucket.name, record.s3.object.key)
     try:
         body = obj.get()["Body"].read()
-
-        # Do something with the data here. Ex. Put in DB for querying
-
         log.info(
             f"Downloaded {record.s3.object.key} from {record.s3.bucket.name} with length {len(body)}"
         )
-        return True
+        return body
     except Exception:
         log.error(
             f"Error downloading {record.s3.object.key} from {record.s3.bucket.name}"

--- a/api/tests/storage/test_storage.py
+++ b/api/tests/storage/test_storage.py
@@ -1,4 +1,3 @@
-import pytest
 from storage import storage
 from unittest.mock import MagicMock, patch
 
@@ -13,7 +12,7 @@ def test_get_object(mock_boto, mock_log):
     mock_client = MagicMock()
     mock_boto.resource.return_value = mock_client
 
-    storage.get_object(mock_record)
+    assert storage.get_object(mock_record) is True
     mock_client.Object.assert_called_once_with("bucket_name", "key")
     mock_client.Object().get().__getitem__.assert_called_once_with("Body")
     mock_log.info.assert_called_once_with(
@@ -36,5 +35,5 @@ def test_get_object_catch_exception(mock_boto, mock_log):
 
     mock_boto.resource.return_value = mock_client
 
-    storage.get_object(mock_record)
+    assert storage.get_object(mock_record) is False
     mock_log.error.assert_called_once_with("Error downloading key from bucket_name")

--- a/api/tests/storage/test_storage.py
+++ b/api/tests/storage/test_storage.py
@@ -1,0 +1,40 @@
+import pytest
+from storage import storage
+from unittest.mock import MagicMock, patch
+
+
+@patch("storage.storage.log")
+@patch("storage.storage.boto3")
+def test_get_object(mock_boto, mock_log):
+    mock_record = MagicMock()
+    mock_record.s3.bucket.name = "bucket_name"
+    mock_record.s3.object.key = "key"
+
+    mock_client = MagicMock()
+    mock_boto.resource.return_value = mock_client
+
+    storage.get_object(mock_record)
+    mock_client.Object.assert_called_once_with("bucket_name", "key")
+    mock_client.Object().get().__getitem__.assert_called_once_with("Body")
+    mock_log.info.assert_called_once_with(
+        "Downloaded key from bucket_name with length 0"
+    )
+
+
+@patch("storage.storage.log")
+@patch("storage.storage.boto3")
+def test_get_object_catch_exception(mock_boto, mock_log):
+    mock_record = MagicMock()
+    mock_record.s3.bucket.name = "bucket_name"
+    mock_record.s3.object.key = "key"
+
+    mock_object = MagicMock()
+    mock_object.get.side_effect = Exception
+
+    mock_client = MagicMock()
+    mock_client.Object.return_value = mock_object
+
+    mock_boto.resource.return_value = mock_client
+
+    storage.get_object(mock_record)
+    mock_log.error.assert_called_once_with("Error downloading key from bucket_name")

--- a/api/tests/storage/test_storage.py
+++ b/api/tests/storage/test_storage.py
@@ -10,13 +10,15 @@ def test_get_object(mock_boto, mock_log):
     mock_record.s3.object.key = "key"
 
     mock_client = MagicMock()
+    mock_client.Object.return_value.get.return_value.__getitem__.return_value.read.return_value = "body"
+
     mock_boto.resource.return_value = mock_client
 
-    assert storage.get_object(mock_record) is True
+    assert storage.get_object(mock_record) == "body"
     mock_client.Object.assert_called_once_with("bucket_name", "key")
     mock_client.Object().get().__getitem__.assert_called_once_with("Body")
     mock_log.info.assert_called_once_with(
-        "Downloaded key from bucket_name with length 0"
+        "Downloaded key from bucket_name with length 4"
     )
 
 

--- a/api/tests/storage/test_storage.py
+++ b/api/tests/storage/test_storage.py
@@ -10,7 +10,9 @@ def test_get_object(mock_boto, mock_log):
     mock_record.s3.object.key = "key"
 
     mock_client = MagicMock()
-    mock_client.Object.return_value.get.return_value.__getitem__.return_value.read.return_value = "body"
+    mock_client.Object.return_value.get.return_value.__getitem__.return_value.read.return_value = (
+        "body"
+    )
 
     mock_boto.resource.return_value = mock_client
 

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -31,7 +31,7 @@ def test_handler_migrate_event_failed(mock_migrate_head):
 
 
 @patch("main.storage")
-def test_handler_record_event_no_s3(mock_storage):
+def test_handler_record_event_no_records(mock_storage):
     assert main.handler({"Records": []}, {}) == "Success"
     mock_storage.get_object.assert_not_called()
 
@@ -40,3 +40,11 @@ def test_handler_record_event_no_s3(mock_storage):
 def test_handler_record_event_contains_s3(mock_storage):
     assert main.handler({"Records": [{"s3": {}}]}, {}) == "Success"
     mock_storage.get_object.assert_called_once_with({"s3": {}})
+
+
+@patch("main.log")
+@patch("main.storage")
+def test_handler_record_event_contains_unrecognised_event(mock_storage, mock_logger):
+    assert main.handler({"Records": [{"sns": {}}]}, {}) == "Success"
+    mock_storage.get_object.assert_not_called()
+    mock_logger.warning.assert_called_once_with("Handler recieved unrecognised record: {'sns': {}}")

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -28,3 +28,15 @@ def test_handler_migrate_event_failed(mock_migrate_head):
     mock_migrate_head.side_effect = Exception()
     assert main.handler({"task": "migrate"}, {}) == "Error"
     mock_migrate_head.assert_called_once()
+
+
+@patch("main.storage")
+def test_handler_record_event_no_s3(mock_storage):
+    assert main.handler({"Records": []}, {}) == "Success"
+    mock_storage.get_object.assert_not_called()
+
+
+@patch("main.storage")
+def test_handler_record_event_contains_s3(mock_storage):
+    assert main.handler({"Records": [{"s3": {}}]}, {}) == "Success"
+    mock_storage.get_object.assert_called_once_with({"s3": {}})

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -47,4 +47,6 @@ def test_handler_record_event_contains_s3(mock_storage):
 def test_handler_record_event_contains_unrecognised_event(mock_storage, mock_logger):
     assert main.handler({"Records": [{"sns": {}}]}, {}) == "Success"
     mock_storage.get_object.assert_not_called()
-    mock_logger.warning.assert_called_once_with("Handler recieved unrecognised record: {'sns': {}}")
+    mock_logger.warning.assert_called_once_with(
+        "Handler recieved unrecognised record: {'sns': {}}"
+    )

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -14,7 +14,7 @@ def test_handler_api_gateway_event(mock_mangum):
 @patch("main.log")
 def test_handler_unmatched_event(mock_logger):
     assert main.handler({}, {}) is False
-    mock_logger.warning.assert_called_once_with("Handler recieved unrecognised event")
+    mock_logger.warning.assert_called_once_with("Handler received unrecognised event")
 
 
 @patch("main.migrate_head")
@@ -48,5 +48,5 @@ def test_handler_record_event_contains_unrecognised_event(mock_storage, mock_log
     assert main.handler({"Records": [{"sns": {}}]}, {}) == "Success"
     mock_storage.get_object.assert_not_called()
     mock_logger.warning.assert_called_once_with(
-        "Handler recieved unrecognised record: {'sns': {}}"
+        "Handler received unrecognised record: {'sns': {}}"
     )

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -35,3 +35,23 @@ resource "aws_lambda_permission" "api" {
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.api.execution_arn}/*/*"
 }
+
+resource "aws_lambda_permission" "api-permission-s3" {
+  statement_id  = "AllowExecutionFromS3Bucket"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.api.function_name
+  principal     = "s3.amazonaws.com"
+  source_arn    = aws_s3_bucket.axe-core-report-data.arn
+}
+
+resource "aws_s3_bucket_notification" "api-notification" {
+  bucket = aws_s3_bucket.axe-core-report-data.id
+
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.api.arn
+    events              = ["s3:ObjectCreated:*"]
+    filter_suffix       = ".json"
+  }
+
+  depends_on = [aws_lambda_permission.api-permission-s3]
+}

--- a/terragrunt/aws/scanners/owasp-zap/network.tf
+++ b/terragrunt/aws/scanners/owasp-zap/network.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "security_tools_web_scanning" {
-  name        = "web-security-scanners-sg "
+  name        = "web-security-scanners-sg"
   description = "Web access for Security Scanners"
   vpc_id      = var.vpc_id
 


### PR DESCRIPTION
This PR adds a trigger to the API lambda to be invoked if an S3 file is added to the axe-core-report-data bucket. The API will invoke, download the file and produce a sample log output. Ideally at this point the API would extract the summary data from the report, write a summary into the database and do whatever else is need for reporting.