### PR TITLE
feat: adds s3 expiry rules

### DIFF
--- a/terragrunt/aws/api/s3.tf
+++ b/terragrunt/aws/api/s3.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket" "axe-core-report-data" {
   bucket = "${var.product_name}-${var.env}-axe-core-report-data"
+  acl    = "private"
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -8,9 +9,27 @@ resource "aws_s3_bucket" "axe-core-report-data" {
     }
   }
 
+  lifecycle_rule {
+    id      = "expire"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
+
   tags = {
     CostCenter = var.billing_code
   }
+}
+
+resource "aws_s3_bucket_public_access_block" "axe-core-report-data" {
+  bucket = aws_s3_bucket.axe-core-report-data.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 resource "aws_s3_bucket" "axe-core-screenshots" {
@@ -23,8 +42,25 @@ resource "aws_s3_bucket" "axe-core-screenshots" {
     }
   }
 
+  lifecycle_rule {
+    id      = "expire"
+    enabled = true
+
+    expiration {
+      days = 30
+    }
+  }
+
   tags = {
     CostCenter = var.billing_code
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "axe-core-screenshots" {
+  bucket = aws_s3_bucket.axe-core-screenshots.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/terragrunt/aws/api/s3.tf
+++ b/terragrunt/aws/api/s3.tf
@@ -34,6 +34,7 @@ resource "aws_s3_bucket_public_access_block" "axe-core-report-data" {
 
 resource "aws_s3_bucket" "axe-core-screenshots" {
   bucket = "${var.product_name}-${var.env}-axe-core-screenshots"
+  acl    = "private"
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {


### PR DESCRIPTION
Closes #16 by adding a 30 day retention policy to reports and images. This affects only the raw data in reports as the DB should retain a summary of most data, which can be used for aggregation. Detailed reports would be gone after 30 days. We can tweak this based on need. 

Images would be lost forever after 30 days. 

This should clean up data if it is no longer useful, assuming things are no longer useful after 30 days.