### PR TITLE
chore: reduce zap image size

### DIFF
--- a/runners/owasp-zap/Dockerfile
+++ b/runners/owasp-zap/Dockerfile
@@ -6,7 +6,14 @@ RUN apk update \
     && apk upgrade \
     && apk add --update curl bash jq
 
-RUN pip install --upgrade zapcli awscli
+RUN pip install --upgrade zapcli
+
+# Install AWS CLI
+ARG AWS_CLI_VERSION="2.2.29"
+RUN curl -Lo awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install -i /usr/local/aws-cli -b /usr/local/bin
+
 COPY entrypoint.sh /entrypoint.sh
 
 # Launch OWASP scan

--- a/scanners/owasp-zap/Dockerfile
+++ b/scanners/owasp-zap/Dockerfile
@@ -70,7 +70,9 @@ ARG git_sha
 ENV GIT_SHA=$git_sha
 
 # (Optional) Add Lambda Runtime Interface Emulator and use a script in the ENTRYPOINT for simpler local runs
-ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie /usr/bin/aws-lambda-rie
+ARG RIE_VERSION=1.1
+RUN wget -O aws-lambda-rie https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/download/${RIE_VERSION}/aws-lambda-rie \
+    && mv aws-lambda-rie /usr/bin/aws-lambda-rie
 COPY bin/entry.sh /
 RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh
 


### PR DESCRIPTION
Pip install of awscli was resulting in the runner-owasp-zap image being > 2 GB. Downloading the zip from aws and copying it to the bin path allows the image sizes to be reduced significantly.