### PR TITLE
feat: Hot reload python files when running locally

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,6 +33,6 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "",
+	// "postCreateCommand": "",
 	"remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,6 +33,6 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip3 install --user -r api/requirements.txt && pip3 install --user -r api/requirements_dev.txt && python -m playwright install chromium",
+	"postCreateCommand": "",
 	"remoteUser": "vscode"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -28,6 +28,8 @@ services:
   api:
     build:
       context: ../api/
+    volumes:
+      - ../api:/function
     environment:
       <<: *db-connection-strings
   db:

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,7 +4,7 @@ ARG FUNCTION_DIR="/function"
 FROM python:3.9-slim-buster
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends ca-certificates curl git gstreamer1.0-libav libnss3-tools libatk-bridge2.0-0 libcups2-dev libxkbcommon-x11-0 libxcomposite-dev libxrandr2 libgbm-dev libgtk-3-0 libxshmfence-dev gnupg2 postgresql-client openssh-client python3-pip vim wget xz-utils zsh \
+    && apt-get -y install --no-install-recommends ca-certificates curl git gstreamer1.0-libav libnss3-tools libatk-bridge2.0-0 libcups2-dev libxkbcommon-x11-0 libxcomposite-dev libxrandr2 libgbm-dev libgtk-3-0 libxshmfence-dev gnupg2 postgresql-client openssh-client python3-pip vim wget xz-utils zsh entr \
     && apt-get autoremove -y && apt-get clean -y
 
 # Include global arg in this stage of the build
@@ -26,7 +26,6 @@ COPY ./requirements.txt ${FUNCTION_DIR}
 
 RUN python3.9 -m pip install -r ${FUNCTION_DIR}/requirements.txt --target /pymodules
 
-RUN apt-get install entr
 # Install the runtime interface client
 RUN pip install \
     --target /pymodules \

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -10,23 +10,30 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # Include global arg in this stage of the build
 ARG FUNCTION_DIR
 
-# Create function directory
-RUN mkdir -p ${FUNCTION_DIR}
+WORKDIR ${FUNCTION_DIR}
+
+RUN mkdir -p /pymodules
+ENV PYTHONPATH=/pymodules
+
+COPY ./requirements_playwright.txt ${FUNCTION_DIR}
+
+RUN python3.9 -m pip install -r ${FUNCTION_DIR}/requirements_playwright.txt 
+
+RUN playwright install chromium
+
+COPY ./requirements.txt ${FUNCTION_DIR}
+
+
+RUN python3.9 -m pip install -r ${FUNCTION_DIR}/requirements.txt --target /pymodules
+
+RUN apt-get install entr
+# Install the runtime interface client
+RUN pip install \
+    --target /pymodules \
+    awslambdaric
 
 # Copy function code
 COPY . ${FUNCTION_DIR}
-
-RUN python3.9 -m pip install -r ${FUNCTION_DIR}/requirements.txt --target ${FUNCTION_DIR}
-
-# Install the runtime interface client
-RUN pip install \
-    --target ${FUNCTION_DIR} \
-    awslambdaric
-
-# Set working directory to function root directory
-WORKDIR ${FUNCTION_DIR}
-
-RUN python -m playwright install chromium
 
 # Set build variables
 ARG git_sha 

--- a/api/bin/entry.sh
+++ b/api/bin/entry.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
-    exec /usr/bin/aws-lambda-rie /usr/local/bin/python -m awslambdaric $1
+    echo "Running aws-lambda-rie"
+    exec find . -name "*.py" | entr -r /usr/bin/aws-lambda-rie /usr/local/bin/python -m awslambdaric "$1"
 else
-    exec /usr/local/bin/python -m awslambdaric $1
+    exec /usr/local/bin/python -m awslambdaric "$1"
 fi

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,8 +4,7 @@ bcrypt==3.2.0
 fastapi==0.67.0
 logzero==1.7.0
 mangum==0.12.1
-playwright==1.13.1
 psycopg2-binary==2.9.1
+SQLAlchemy==1.4.22
 scrapy==2.5.0
 scrapy-playwright==0.0.4
-SQLAlchemy==1.4.22

--- a/api/requirements_playwright.txt
+++ b/api/requirements_playwright.txt
@@ -1,0 +1,1 @@
+playwright==1.13.1


### PR DESCRIPTION
# Summary | Résumé

This PR does a couple of things.

First it reworks the Dockerfile for the API so that it runs expensive commands first so we can take advantage of caching.

For instance it will install playwright and chromium up front since those are slow and as it stands will always re-run whenever files change.

Secondly it installs the python modules in a different folder then the api code and sets the `PYTHONPATH` env variable to that folder so that we can mount the `api` folder as a volume mounted to `/function/` in the container.

Thirdly it installs `entr` and uses that to watch for changes to all *.py files in the api folder and subdirectories, when those files change it will restart aws-lambda-rie.

Closes #91

# Test instructions | Instructions pour tester la modification

Run the branch in a devcontainer, make a change to the python code, hit the endpoint and see the new code change occur.
