### PR TITLE
feat: sql tool and make migrations fix

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,12 +20,26 @@
 		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
 		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
 		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+		"sqltools.connections": [
+			{
+				"name": "Container database",
+				"driver": "PostgreSQL",
+				"previewLimit": 50,
+				"server": "db",
+				"port": 5432,
+				"database": "scan-websites",
+				"username": "postgres",
+				"password": "postgres"
+			}
+		],
 		"terminal.integrated.shell.linux": "/bin/zsh"
 	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-python.python",
 		"ms-python.vscode-pylance",
+		"mtxr.sqltools",
+		"mtxr.sqltools-driver-pg",
 		"redhat.vscode-yaml",
 		"timonwong.shellcheck",
 		"hashicorp.terraform"

--- a/api/database/migrate.py
+++ b/api/database/migrate.py
@@ -4,4 +4,5 @@ from alembic import command
 
 def migrate_head():
     alembic_cfg = Config("./db_migrations/alembic.ini")
+    alembic_cfg.set_main_option("script_location", "./db_migrations")
     command.upgrade(alembic_cfg, "head")

--- a/api/db_migrations/alembic.ini
+++ b/api/db_migrations/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = ./db_migrations
+script_location = .
 
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -31,6 +31,7 @@ def setup_db():
         "SQLALCHEMY_DATABASE_TEST_URI"
     )
     alembic_cfg = Config("./db_migrations/alembic.ini")
+    alembic_cfg.set_main_option("script_location", "./db_migrations")
     command.downgrade(alembic_cfg, "base")
     command.upgrade(alembic_cfg, "head")
 


### PR DESCRIPTION
Adds a SQL tool to the dev container which shortcuts psql and gives you some more options to work with the DB.

Also fixes a bug where you could not run migrations both from the make file and the code.

![Screen Shot 2021-08-23 at 1 15 41 PM](https://user-images.githubusercontent.com/867334/130489377-1f06c528-d305-4c96-bc74-c916bd5bcc1e.png)
![Screen Shot 2021-08-23 at 1 15 50 PM](https://user-images.githubusercontent.com/867334/130489388-c92c69e2-bc28-49d3-a104-8c5842aa09c1.png)
![Screen Shot 2021-08-23 at 1 16 14 PM](https://user-images.githubusercontent.com/867334/130489397-bcd1897a-6b86-409a-909d-fcf87cdb435e.png)
