### PR TITLE
feat: adds AWS powertools for metrics

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,5 +1,6 @@
 from mangum import Mangum
 from api_gateway import api
+from aws_lambda_powertools import Metrics
 from logger import log
 from database.migrate import migrate_head
 from storage import storage
@@ -18,6 +19,7 @@ from models.TemplateScanTrigger import TemplateScanTrigger  # noqa: F401
 from models.User import User  # noqa: F401
 
 app = api.app
+metrics = Metrics(namespace="ScanWebsites", service="api")
 
 
 def print_env_variables():
@@ -25,6 +27,7 @@ def print_env_variables():
     log.info(f"AWS_LAMBDA_RUNTIME_API: {rapi}")
 
 
+@metrics.log_metrics(capture_cold_start_metric=True)
 def handler(event, context):
     print_env_variables()
     log.debug(event)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,7 +1,8 @@
 alembic==1.6.5
 aiofiles==0.7.0
+aws-lambda-powertools==1.20.1
 babel==2.9.1
-boto3==1.17.84
+boto3==1.18.31
 bcrypt==3.2.0
 fastapi==0.67.0
 jinja2==3.0.1

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from unittest.mock import MagicMock
 
 from alembic.config import Config
 from alembic import command
@@ -10,7 +11,6 @@ from models.Scan import Scan
 from models.ScanType import ScanType
 from models.Template import Template
 from models.TemplateScan import TemplateScan
-from models.User import User
 
 
 from sqlalchemy import create_engine
@@ -41,11 +41,17 @@ def assert_new_model_saved():
     return f
 
 
+@pytest.fixture
+def context_fixture():
+    context = MagicMock()
+    context.function_name = "api"
+    return context
+
+
 @pytest.fixture(scope="session")
 def organisation_fixture(session):
     organisation = Organisation(name="fixture_name")
     session.add(organisation)
-
     return organisation
 
 
@@ -61,7 +67,6 @@ def setup_db():
     os.environ["SQLALCHEMY_DATABASE_URI"] = os.environ.get(
         "SQLALCHEMY_DATABASE_TEST_URI"
     )
-
     alembic_cfg = Config("./db_migrations/alembic.ini")
     alembic_cfg.set_main_option("script_location", "./db_migrations")
     command.downgrade(alembic_cfg, "base")
@@ -104,10 +109,3 @@ def template_scan_fixture(scan_type_fixture, template_fixture, session):
     )
     session.add(template_scan)
     return template_scan
-
-
-@pytest.fixture(scope="session")
-def user_fixture(session):
-    user = User(name="fixture_name")
-    session.add(user)
-    return user

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -1,38 +1,49 @@
 import main
+import json
 from unittest.mock import MagicMock, patch
 
 
 @patch("main.Mangum")
-def test_handler_api_gateway_event(mock_mangum):
+def test_handler_api_gateway_event(mock_mangum, context_fixture, capsys):
     mock_asgi_handler = MagicMock()
     mock_asgi_handler.return_value = True
     mock_mangum.return_value = mock_asgi_handler
-    assert main.handler({"httpMethod": "GET"}, {}) is True
-    mock_asgi_handler.assert_called_once_with({"httpMethod": "GET"}, {})
+    assert main.handler({"httpMethod": "GET"}, context_fixture) is True
+    mock_asgi_handler.assert_called_once_with({"httpMethod": "GET"}, context_fixture)
+
+    log = capsys.readouterr().out.strip()
+    metrics_output = json.loads(log)
+
+    assert "ScanWebsites" in log
+    assert (
+        "ColdStart"
+        in metrics_output["_aws"]["CloudWatchMetrics"][0]["Metrics"][0]["Name"]
+    )
+    assert metrics_output["function_name"] == "api"
 
 
 @patch("main.log")
-def test_handler_unmatched_event(mock_logger):
-    assert main.handler({}, {}) is False
+def test_handler_unmatched_event(mock_logger, context_fixture):
+    assert main.handler({}, context_fixture) is False
     mock_logger.warning.assert_called_once_with("Handler received unrecognised event")
 
 
 @patch("main.migrate_head")
-def test_handler_migrate_event(mock_migrate_head):
-    assert main.handler({"task": "migrate"}, {}) == "Success"
+def test_handler_migrate_event(mock_migrate_head, context_fixture):
+    assert main.handler({"task": "migrate"}, context_fixture) == "Success"
     mock_migrate_head.assert_called_once()
 
 
 @patch("main.migrate_head")
-def test_handler_migrate_event_failed(mock_migrate_head):
+def test_handler_migrate_event_failed(mock_migrate_head, context_fixture):
     mock_migrate_head.side_effect = Exception()
-    assert main.handler({"task": "migrate"}, {}) == "Error"
+    assert main.handler({"task": "migrate"}, context_fixture) == "Error"
     mock_migrate_head.assert_called_once()
 
 
 @patch("main.storage")
-def test_handler_record_event_no_records(mock_storage):
-    assert main.handler({"Records": []}, {}) == "Success"
+def test_handler_record_event_no_records(mock_storage, context_fixture):
+    assert main.handler({"Records": []}, context_fixture) == "Success"
     mock_storage.get_object.assert_not_called()
 
 


### PR DESCRIPTION
Closes #92. This PR uses AWS powertools for metrics collection. Currently it only measures lambda cold starts but it can be easily used for other metrics across the API.