### PR TITLE
Feat/crawler ratelimit

### DIFF
--- a/api/api_gateway/routers/scans.py
+++ b/api/api_gateway/routers/scans.py
@@ -9,13 +9,16 @@ import uuid
 limiter = Limiter(key_func=get_remote_address, enabled=True)
 router = APIRouter()
 
+
 class CrawlUrl(BaseModel):
     url: str
 
 
 @router.post("/crawl")
 @limiter.limit("5/minute")
-def crawl_endpoint(crawl_url: CrawlUrl, background_tasks: BackgroundTasks, request: Request):
+def crawl_endpoint(
+    crawl_url: CrawlUrl, background_tasks: BackgroundTasks, request: Request
+):
     log.info(f"Crawling {crawl_url}")
     background_tasks.add_task(crawl, str(uuid.uuid4()), crawl_url.url)
     return {"message": "Crawler initiated"}

--- a/api/api_gateway/routers/scans.py
+++ b/api/api_gateway/routers/scans.py
@@ -1,18 +1,21 @@
-from fastapi import APIRouter, BackgroundTasks
+from fastapi import APIRouter, BackgroundTasks, Request
 from logger import log
 from pydantic import BaseModel
 from crawler.crawler import crawl
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 import uuid
 
+limiter = Limiter(key_func=get_remote_address, enabled=True)
 router = APIRouter()
-
 
 class CrawlUrl(BaseModel):
     url: str
 
 
 @router.post("/crawl")
-def crawl_endpoint(crawl_url: CrawlUrl, background_tasks: BackgroundTasks):
+@limiter.limit("5/minute")
+def crawl_endpoint(crawl_url: CrawlUrl, background_tasks: BackgroundTasks, request: Request):
     log.info(f"Crawling {crawl_url}")
     background_tasks.add_task(crawl, str(uuid.uuid4()), crawl_url.url)
     return {"message": "Crawler initiated"}

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -11,3 +11,4 @@ psycopg2-binary==2.9.1
 SQLAlchemy==1.4.22
 scrapy==2.5.0
 scrapy-playwright==0.0.4
+slowapi==0.1.5

--- a/api/tests/api_gateway/test_api.py
+++ b/api/tests/api_gateway/test_api.py
@@ -42,17 +42,33 @@ def test_healthcheck_failure(mock_log, mock_get_db_version):
     # assert mock_log.error.assert_called_once_with(SQLAlchemyError())
 
 
-# @patch("api_gateway.api.crawl")
-# @patch("api_gateway.api.log")
-# @patch("api_gateway.api.uuid")
-# def test_crawl(mock_uuid, mock_log, mock_crawl):
-#    fake_url = "bar"
-#    fake_uuid = "foo"
-#    mock_log.return_value = None
-#    mock_uuid.uuid4.return_value = fake_uuid
-#
-#    response = client.post(url="/crawl", json={"url": fake_url})
-#
-#    assert response.status_code == 200
-#    mock_crawl.assert_called_once_with(fake_uuid, fake_url)
-#    mock_log.info.assert_called_once_with("Crawling url='bar'")
+@patch("api_gateway.routers.scans.crawl")
+@patch("api_gateway.routers.scans.log")
+@patch("api_gateway.routers.scans.uuid")
+def test_crawl(mock_uuid, mock_log, mock_crawl):
+   fake_url = "bar"
+   fake_uuid = "foo"
+   mock_log.return_value = None
+   mock_uuid.uuid4.return_value = fake_uuid
+
+   response = client.post(url="/scans/crawl", json={"url": fake_url})
+
+   assert response.status_code == 200
+   mock_crawl.assert_called_once_with(fake_uuid, fake_url)
+   mock_log.info.assert_called_once_with("Crawling url='bar'")
+
+@patch("api_gateway.routers.scans.crawl")
+@patch("api_gateway.routers.scans.log")
+@patch("api_gateway.routers.scans.uuid")
+def test_crawl_ratelimit(mock_uuid, mock_log, mock_crawl):
+   fake_url = "bar"
+   fake_uuid = "foo"
+   mock_log.return_value = None
+   mock_uuid.uuid4.return_value = fake_uuid
+
+   for i in range(0, 10):
+    response = client.post(url="/scans/crawl", json={"url": fake_url})
+    if i < 4:
+      assert response.status_code == 200
+    else:
+      assert response.status_code == 429   

--- a/api/tests/api_gateway/test_api.py
+++ b/api/tests/api_gateway/test_api.py
@@ -46,29 +46,30 @@ def test_healthcheck_failure(mock_log, mock_get_db_version):
 @patch("api_gateway.routers.scans.log")
 @patch("api_gateway.routers.scans.uuid")
 def test_crawl(mock_uuid, mock_log, mock_crawl):
-   fake_url = "bar"
-   fake_uuid = "foo"
-   mock_log.return_value = None
-   mock_uuid.uuid4.return_value = fake_uuid
+    fake_url = "bar"
+    fake_uuid = "foo"
+    mock_log.return_value = None
+    mock_uuid.uuid4.return_value = fake_uuid
 
-   response = client.post(url="/scans/crawl", json={"url": fake_url})
+    response = client.post(url="/scans/crawl", json={"url": fake_url})
 
-   assert response.status_code == 200
-   mock_crawl.assert_called_once_with(fake_uuid, fake_url)
-   mock_log.info.assert_called_once_with("Crawling url='bar'")
+    assert response.status_code == 200
+    mock_crawl.assert_called_once_with(fake_uuid, fake_url)
+    mock_log.info.assert_called_once_with("Crawling url='bar'")
+
 
 @patch("api_gateway.routers.scans.crawl")
 @patch("api_gateway.routers.scans.log")
 @patch("api_gateway.routers.scans.uuid")
 def test_crawl_ratelimit(mock_uuid, mock_log, mock_crawl):
-   fake_url = "bar"
-   fake_uuid = "foo"
-   mock_log.return_value = None
-   mock_uuid.uuid4.return_value = fake_uuid
+    fake_url = "bar"
+    fake_uuid = "foo"
+    mock_log.return_value = None
+    mock_uuid.uuid4.return_value = fake_uuid
 
-   for i in range(0, 10):
-    response = client.post(url="/scans/crawl", json={"url": fake_url})
-    if i < 4:
-      assert response.status_code == 200
-    else:
-      assert response.status_code == 429   
+    for i in range(0, 10):
+        response = client.post(url="/scans/crawl", json={"url": fake_url})
+        if i < 4:
+            assert response.status_code == 200
+        else:
+            assert response.status_code == 429


### PR DESCRIPTION
Closes #105. Crawler rate limited to 5 requests / minute from a single IP until authentication introduced to scan-websites 