### PR TITLE
feat: add Route53 hosted zone

### DIFF
--- a/.github/workflows/tf_apply.yml
+++ b/.github/workflows/tf_apply.yml
@@ -45,6 +45,9 @@ jobs:
             api:
               - 'terragrunt/aws/api/**'
               - 'terragrunt/env/api/**'
+            hosted_zone:
+              - 'terragrunt/aws/hosted_zone/**'
+              - 'terragrunt/env/hosted_zone/**'              
             scanners-axe-core:
               - 'terragrunt/aws/scanners/axe-core/**'
               - 'terragrunt/env/scanners/axe-core/**'
@@ -58,6 +61,12 @@ jobs:
         run: |
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
+      - name: Apply hosted_zone
+        if: ${{ steps.filter.outputs.hosted_zone == 'true' }}
+        working-directory: terragrunt/env/hosted_zone
+        run: |
+          terragrunt apply --terragrunt-non-interactive -auto-approve      
+
       - name: Apply scanners/axe-core
         if: ${{ steps.filter.outputs.scanners-axe-core == 'true' }}
         working-directory: terragrunt/env/scanners/axe-core
@@ -68,4 +77,4 @@ jobs:
         if: ${{ steps.filter.outputs.scanners-owasp-zap == 'true' }}
         working-directory: terragrunt/env/scanners/owasp-zap
         run: |
-          terragrunt apply --terragrunt-non-interactive -auto-approve          
+          terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf_plan.yml
+++ b/.github/workflows/tf_plan.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         include:
           - module: api
+          - module: hosted_zone
           - module: scanners/axe-core
           - module: scanners/owasp-zap
 

--- a/terragrunt/aws/hosted_zone/hosted_zone.tf
+++ b/terragrunt/aws/hosted_zone/hosted_zone.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_zone" "scan_websites" {
+  name = var.hosted_zone_name
+
+  tags = {
+    CostCenter = var.billing_code
+  }
+}

--- a/terragrunt/aws/hosted_zone/inputs.tf
+++ b/terragrunt/aws/hosted_zone/inputs.tf
@@ -1,0 +1,4 @@
+variable "hosted_zone_name" {
+  description = "(Required) Name of the Route53 hosted zone"
+  type        = string
+}

--- a/terragrunt/aws/hosted_zone/outputs.tf
+++ b/terragrunt/aws/hosted_zone/outputs.tf
@@ -1,0 +1,3 @@
+output "hosted_zone_id" {
+  value = aws_route53_zone.scan_websites.zone_id
+}

--- a/terragrunt/env/hosted_zone/terragrunt.hcl
+++ b/terragrunt/env/hosted_zone/terragrunt.hcl
@@ -1,0 +1,11 @@
+terraform {
+  source = "../../aws//hosted_zone"
+}
+
+inputs = {
+  hosted_zone_name = "scan-websites.alpha.canada.ca"
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary
This creates a hosted zone named `scan-websites.alpha.canada.ca` that will be used to manage the scan websites DNS records.

Closes #117  
Related #118 