### PR TITLE
feat: API stage custom domain and certificate

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -6,11 +6,7 @@ from starlette.middleware.sessions import SessionMiddleware
 from front_end import view
 from .routers import auth, ops, organisations, scans
 
-if "DEV_ENVIRONMENT" in environ:
-    app = FastAPI()
-else:
-    # This is only needed until a dedicated domain name is live
-    app = FastAPI(root_path="/v1")
+app = FastAPI()
 
 FASTAPI_SECRET_KEY = environ.get("FASTAPI_SECRET_KEY") or None
 if FASTAPI_SECRET_KEY is None:

--- a/terragrunt/aws/api/api_gateway.tf
+++ b/terragrunt/aws/api/api_gateway.tf
@@ -17,6 +17,12 @@ resource "aws_api_gateway_domain_name" "api" {
   }
 }
 
+resource "aws_api_gateway_base_path_mapping" "api" {
+  api_id      = aws_api_gateway_rest_api.api.id
+  stage_name  = aws_api_gateway_stage.api.stage_name
+  domain_name = aws_api_gateway_domain_name.api.domain_name
+}
+
 resource "aws_api_gateway_resource" "resource" {
   rest_api_id = aws_api_gateway_rest_api.api.id
   parent_id   = aws_api_gateway_rest_api.api.root_resource_id

--- a/terragrunt/aws/api/api_gateway.tf
+++ b/terragrunt/aws/api/api_gateway.tf
@@ -7,6 +7,16 @@ resource "aws_api_gateway_rest_api" "api" {
   }
 }
 
+resource "aws_api_gateway_domain_name" "api" {
+  regional_certificate_arn = aws_acm_certificate_validation.scan_websites_certificate_validation.certificate_arn
+  domain_name              = var.domain_name
+  security_policy          = "TLS_1_2"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}
+
 resource "aws_api_gateway_resource" "resource" {
   rest_api_id = aws_api_gateway_rest_api.api.id
   parent_id   = aws_api_gateway_rest_api.api.root_resource_id

--- a/terragrunt/aws/api/certificate.tf
+++ b/terragrunt/aws/api/certificate.tf
@@ -1,0 +1,37 @@
+resource "aws_acm_certificate" "scan_websites_certificate" {
+  domain_name               = var.domain_name
+  subject_alternative_names = ["*.${var.domain_name}"]
+  validation_method         = "DNS"
+
+  tags = {
+    CostCenter = var.billing_code
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "scan_websites_dns_validation" {
+  zone_id = var.hosted_zone_id
+
+  for_each = {
+    for dvo in aws_acm_certificate.scan_websites_certificate.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
+
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "scan_websites_certificate_validation" {
+  certificate_arn         = aws_acm_certificate.scan_websites_certificate.arn
+  validation_record_fqdns = [for record in aws_route53_record.scan_websites_dns_validation : record.fqdn]
+}

--- a/terragrunt/aws/api/inputs.tf
+++ b/terragrunt/aws/api/inputs.tf
@@ -21,3 +21,11 @@ variable "google_client_secret" {
   type      = string
   sensitive = true
 }
+
+variable "domain_name" {
+  type = string
+}
+
+variable "hosted_zone_id" {
+  type = string
+}

--- a/terragrunt/aws/api/route53.tf
+++ b/terragrunt/aws/api/route53.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_record" "scan_websites_A" {
+  zone_id = var.hosted_zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_api_gateway_domain_name.api.regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.api.regional_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terragrunt/env/api/terragrunt.hcl
+++ b/terragrunt/env/api/terragrunt.hcl
@@ -2,9 +2,23 @@ terraform {
   source = "../../aws//api"
 }
 
+dependencies {
+  paths = ["../hosted_zone"]
+}
+
+dependency "hosted_zone" {
+  config_path = "../hosted_zone"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    hosted_zone_id = ""
+  }
+}
 
 inputs = {
-  rds_username = "databaseuser"
+  rds_username   = "databaseuser"
+  hosted_zone_id = dependency.hosted_zone.outputs.hosted_zone_id
+  domain_name    = "scan-websites.alpha.canada.ca"
 }
 
 include {


### PR DESCRIPTION
# Summary
This creates a custom domain name, certificate and DNS "A" record for `scan-websites.alpha.canada.ca`.

Closes #118 