### PR TITLE
fix: allow lambda api to egress on port 443

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -20,7 +20,7 @@ resource "aws_lambda_function" "api" {
   }
 
   vpc_config {
-    security_group_ids = [module.rds.proxy_security_group_id]
+    security_group_ids = [module.rds.proxy_security_group_id, aws_security_group.api.id]
     subnet_ids         = module.vpc.private_subnet_ids
   }
 

--- a/terragrunt/aws/api/vpc.tf
+++ b/terragrunt/aws/api/vpc.tf
@@ -6,17 +6,6 @@ module "vpc" {
   enable_flow_log   = false
 }
 
-resource "aws_network_acl_rule" "https_egress" {
-  network_acl_id = module.vpc.main_nacl_id
-  rule_number    = 100
-  egress         = true
-  protocol       = "tcp"
-  rule_action    = "allow"
-  cidr_block     = "0.0.0.0/0"
-  from_port      = 443
-  to_port        = 443
-}
-
 resource "aws_security_group" "api" {
 
   name        = "${var.product_name}_api_sg"

--- a/terragrunt/aws/api/vpc.tf
+++ b/terragrunt/aws/api/vpc.tf
@@ -8,7 +8,7 @@ module "vpc" {
 
 resource "aws_network_acl_rule" "https" {
   network_acl_id = module.vpc.main_nacl_id
-  rule_number    = 100
+  rule_number    = 110
   egress         = false
   protocol       = "tcp"
   rule_action    = "allow"
@@ -19,7 +19,7 @@ resource "aws_network_acl_rule" "https" {
 
 resource "aws_network_acl_rule" "ephemeral_ports" {
   network_acl_id = module.vpc.main_nacl_id
-  rule_number    = 101
+  rule_number    = 111
   egress         = false
   protocol       = "tcp"
   rule_action    = "allow"
@@ -30,7 +30,7 @@ resource "aws_network_acl_rule" "ephemeral_ports" {
 
 resource "aws_network_acl_rule" "https_egress" {
   network_acl_id = module.vpc.main_nacl_id
-  rule_number    = 100
+  rule_number    = 110
   egress         = true
   protocol       = "tcp"
   rule_action    = "allow"
@@ -41,7 +41,7 @@ resource "aws_network_acl_rule" "https_egress" {
 
 resource "aws_network_acl_rule" "ephemeral_ports_egress" {
   network_acl_id = module.vpc.main_nacl_id
-  rule_number    = 101
+  rule_number    = 111
   egress         = true
   protocol       = "tcp"
   rule_action    = "allow"

--- a/terragrunt/aws/api/vpc.tf
+++ b/terragrunt/aws/api/vpc.tf
@@ -6,6 +6,17 @@ module "vpc" {
   enable_flow_log   = false
 }
 
+resource "aws_network_acl_rule" "https_egress" {
+  network_acl_id = module.vpc.main_nacl_id
+  rule_number    = 100
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 443
+  to_port        = 443
+}
+
 resource "aws_security_group" "api" {
 
   name        = "${var.product_name}_api_sg"

--- a/terragrunt/aws/api/vpc.tf
+++ b/terragrunt/aws/api/vpc.tf
@@ -5,3 +5,23 @@ module "vpc" {
   high_availability = true
   enable_flow_log   = false
 }
+
+resource "aws_security_group" "api" {
+
+  name        = "${var.product_name}_api_sg"
+  description = "SG for the API lambda"
+
+  vpc_id = module.vpc.vpc_id
+
+  tags = {
+    CostCentre = var.billing_code
+    Name       = "${var.product_name}_api_sg"
+  }
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/terragrunt/aws/api/vpc.tf
+++ b/terragrunt/aws/api/vpc.tf
@@ -6,6 +6,50 @@ module "vpc" {
   enable_flow_log   = false
 }
 
+resource "aws_network_acl_rule" "https" {
+  network_acl_id = module.vpc.main_nacl_id
+  rule_number    = 100
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 443
+  to_port        = 443
+}
+
+resource "aws_network_acl_rule" "ephemeral_ports" {
+  network_acl_id = module.vpc.main_nacl_id
+  rule_number    = 101
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 1024
+  to_port        = 65535
+}
+
+resource "aws_network_acl_rule" "https_egress" {
+  network_acl_id = module.vpc.main_nacl_id
+  rule_number    = 100
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 443
+  to_port        = 443
+}
+
+resource "aws_network_acl_rule" "ephemeral_ports_egress" {
+  network_acl_id = module.vpc.main_nacl_id
+  rule_number    = 101
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 1024
+  to_port        = 65535
+}
+
 resource "aws_security_group" "api" {
 
   name        = "${var.product_name}_api_sg"


### PR DESCRIPTION
Closes #121. Cann't authenticate with google if egress on port 443 is blocked. This PR will now allow the lambda api to connect externally to https services