### PR TITLE
fix: remove public read on screenshots

### DIFF
--- a/scanners/axe-core/src/impl.test.ts
+++ b/scanners/axe-core/src/impl.test.ts
@@ -96,7 +96,6 @@ describe("Impl", () => {
         Body: Buffer.from("I'm a string!", "utf-8"),
         ContentType: "image/png",
         Key: "bar.png",
-        ACL: "public-read",
       });
 
       expect(storeMock.putObject).toHaveBeenCalledWith({

--- a/scanners/axe-core/src/impl.ts
+++ b/scanners/axe-core/src/impl.ts
@@ -32,11 +32,8 @@ export async function Impl(
         url = slug;
         await page.setContent(fragment, { waitUntil: "networkidle0" });
       }
-      console.log(`url: ${url}`);
       await takeScreenshot(store, payload.id, page, screenshotBucket);
-      console.log("screenshot taken");
       await createReport(store, url, page, payload, reportBucket);
-      console.log("report saved");
     });
   } catch (error) {
     console.log(error);
@@ -60,7 +57,6 @@ export async function convertEventToRecords(
     // Parse the correct message body, SNS or S3
     // eslint-disable-next-line no-prototype-builtins
     if (record.hasOwnProperty("s3")) {
-      console.log("S3 event");
       const object = await store
         .getObject({
           Bucket: record.s3.bucket.name,
@@ -74,7 +70,6 @@ export async function convertEventToRecords(
         html: data.html,
       });
     } else {
-      console.log("SNS event");
       records.push({
         payload: JSON.parse(record.Sns.Message),
         html: "",
@@ -149,7 +144,6 @@ const takeScreenshot = async (
       Key: `${id}.png`,
       Body: screenshot as Buffer | Uint8Array | string,
       ContentType: "image/png",
-      ACL: "public-read",
     })
     .promise();
 };

--- a/scanners/axe-core/src/index.ts
+++ b/scanners/axe-core/src/index.ts
@@ -50,7 +50,6 @@ export const handler = async (event: SNSEvent | S3Event): Promise<boolean> => {
 
   const reportBucket = process.env.REPORT_DATA_BUCKET;
   const screenshotBucket = process.env.SCREENSHOT_BUCKET;
-  console.log(reportBucket, screenshotBucket);
   const records = await convertEventToRecords(event, s3);
   return await Impl(records, browser, s3, reportBucket, screenshotBucket);
 };


### PR DESCRIPTION
This PR fixes an access issue to the S3 screenshot bucket. We agreed not to have a public bucket and just front the assets through Cloudfront at a later point in time.