### PR TITLE
feat: add Terragrunt to `Lint` GitHub workflow

### DIFF
--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -7,6 +7,7 @@ on:
       - scanners/axe-core/**
       - scanners/owasp-zap/**
       - terragrunt/**
+      - .github/workflows/ci_code.yml
 
 env:
   TERRAGRUNT_VERSION: v0.31.1

--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -6,6 +6,7 @@ on:
       - api/**
       - scanners/axe-core/**
       - scanners/owasp-zap/**
+      - terragrunt/**
 
 env:
   TERRAGRUNT_VERSION: v0.31.1
@@ -27,23 +28,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          folder: ["api", "scanners/axe-core", "scanners/owasp-zap"] 
+          folder: ["api", "scanners/axe-core", "scanners/owasp-zap", "terragrunt"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Check for changes
+        uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # v2.10.2
+        id: filter
+        with:
+          filters: |
+            changes:
+              - '${{ matrix.folder }}/**'
+              - '.github/workflows/ci_code.yml'
+
       - name: Setup python
+        if: ${{ steps.filter.outputs.changes == 'true' }}
         uses: actions/setup-python@v2
         with:
           python-version: "3.9"
 
       - name: Setup node
+        if: ${{ steps.filter.outputs.changes == 'true' && matrix.folder != 'terragrunt' }}
         uses: actions/setup-node@v2
         with:
           node-version: "14"
 
       - name: Setup Terragrunt
+        if: ${{ steps.filter.outputs.changes == 'true' && matrix.folder == 'terragrunt' }}
         run: |
           mkdir -p bin
           wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/$TERRAGRUNT_VERSION/terragrunt_linux_amd64
@@ -51,22 +64,27 @@ jobs:
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
 
       - name: Install dev dependencies
+        if: ${{ steps.filter.outputs.changes == 'true' }}
         working-directory: ${{ matrix.folder }}
         run: make install-dev
 
       - name: Install dependencies
+        if: ${{ steps.filter.outputs.changes == 'true' }}
         working-directory: ${{ matrix.folder }}
         run: make install
 
       - name: Lint
+        if: ${{ steps.filter.outputs.changes == 'true' }}
         working-directory: ${{ matrix.folder }}
         run: make lint-ci
 
       - name: Format
+        if: ${{ steps.filter.outputs.changes == 'true' }}
         working-directory: ${{ matrix.folder }}
         run: make fmt-ci
 
       - name: Test
+        if: ${{ steps.filter.outputs.changes == 'true' }}
         working-directory: ${{ matrix.folder }}
         env:
           SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@127.0.0.1/scan-websites


### PR DESCRIPTION
# Summary 
* Add the `terragrunt` folder to the matrix jobs to lint and format check the code.
* Add a check for changes within each matrix folder to exit early if there's no new code.

**Note:** although it would work to remove the `matrix` and use the root level `Makefile` to execute the workflow steps, using a matrix approach is faster as each folder will run in parallel.

Related #132 

