### PR TITLE
fix: move hsts functionality from api gateway to application layer

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -7,6 +7,7 @@ from starlette.middleware.sessions import SessionMiddleware
 
 from front_end import view
 from .routers import auth, dev, ops, organisations, scans
+from .custom_middleware import HSTSHeaderMiddleware
 
 app = FastAPI()
 
@@ -16,6 +17,8 @@ if FASTAPI_SECRET_KEY is None:
 
 app.add_middleware(AuthenticationMiddleware, backend=auth.SessionAuthBackend())
 app.add_middleware(SessionMiddleware, secret_key=FASTAPI_SECRET_KEY)
+app.add_middleware(HSTSHeaderMiddleware)
+
 
 app.include_router(auth.router)
 app.include_router(ops.router, prefix="/ops", tags=["ops"])

--- a/api/api_gateway/custom_middleware.py
+++ b/api/api_gateway/custom_middleware.py
@@ -1,0 +1,12 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class HSTSHeaderMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, header_value="max-age=300; includeSubDomains; preload"):
+        super().__init__(app)
+        self.header_value = header_value
+
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        response.headers["Strict-Transport-Security"] = self.header_value
+        return response

--- a/api/api_gateway/custom_middleware.py
+++ b/api/api_gateway/custom_middleware.py
@@ -1,12 +1,7 @@
-from starlette.middleware.base import BaseHTTPMiddleware
+from fastapi import Request
 
 
-class HSTSHeaderMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app, header_value="max-age=300; includeSubDomains; preload"):
-        super().__init__(app)
-        self.header_value = header_value
-
-    async def dispatch(self, request, call_next):
-        response = await call_next(request)
-        response.headers["Strict-Transport-Security"] = self.header_value
-        return response
+async def add_security_headers(request: Request, call_next):
+    response = await call_next(request)
+    response.headers["Strict-Transport-Security"] = "max-age=300 ; includeSubDomains"
+    return response

--- a/api/api_gateway/routers/auth.py
+++ b/api/api_gateway/routers/auth.py
@@ -101,6 +101,7 @@ async def auth_google(
 @router.get("/logout")
 async def logout(request: Request):
     request.session.pop("user", None)
+    request.cookies.clear()
     return RedirectResponse(url="/")
 
 

--- a/api/tests/api_gateway/test_api.py
+++ b/api/tests/api_gateway/test_api.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from fastapi.testclient import TestClient
 from unittest.mock import ANY, patch
@@ -41,6 +42,13 @@ def test_healthcheck_failure(mock_log, mock_get_db_version):
     expected_val = {"database": {"able_to_connect": False}}
     assert response.json() == expected_val
     # assert mock_log.error.assert_called_once_with(SQLAlchemyError())
+
+
+def test_hsts_in_response(hsts_middleware_client):
+    response = hsts_middleware_client.get("/ops/version")
+    assert response.status_code == 200
+    pattern = re.compile("max-age=[0-9]+ ; includeSubDomains")
+    assert pattern.match(response.headers["Strict-Transport-Security"])
 
 
 @patch("api_gateway.routers.scans.crawl")

--- a/terragrunt/aws/api/api_gateway.tf
+++ b/terragrunt/aws/api/api_gateway.tf
@@ -77,9 +77,6 @@ resource "aws_api_gateway_integration_response" "integration_response" {
   response_templates = {
     "application/json" = ""
   }
-  response_parameters = {
-    "method.response.header.Strict-Transport-Security" = "max-age=300; includeSubDomains; preload"
-  }
 }
 
 # checkov:skip=CKV_AWS_59:Serving publiclicy accessible content
@@ -130,10 +127,6 @@ resource "aws_api_gateway_integration_response" "root_integration_response" {
 
   response_templates = {
     "text/html" = ""
-  }
-
-  response_parameters = {
-    "method.response.header.Strict-Transport-Security" = "max-age=300; includeSubDomains; preload"
   }
 }
 


### PR DESCRIPTION
First attempt to [set hsts at the api gateway](https://github.com/cds-snc/scan-websites/runs/3725043252) failed due to proxy integrations not allowing transforming responses. `Proxy integrations cannot be configured to transform responses`

This PR will move that functionality to fastapi via custom middleware.