### PR TITLE
fix: checkov warnings with Terraform

### DIFF
--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -1,21 +1,15 @@
 skip-check:
-  - CKV_AWS_18
-  - CKV_AWS_21
-  - CKV_AWS_50
-  - CKV_AWS_59
-  - CKV_AWS_73
-  - CKV_AWS_76
-  - CKV_AWS_108
-  - CKV_AWS_109
-  - CKV_AWS_111
-  - CKV_AWS_115
-  - CKV_AWS_116
-  - CKV_AWS_117
-  - CKV_AWS_120
-  - CKV_AWS_136
-  - CKV_AWS_144
-  - CKV_AWS_145
-  - CKV_AWS_173
-  - CKV2_AWS_4
-  - CKV2_AWS_5
-  - CKV2_AWS_29
+  - CKV_AWS_51  # ECR: `latest` tag is used for development
+  - CKV_AWS_59  # API Gateway: anonymous access required by API
+  - CKV_AWS_73  # API Gateway: X-ray tracing not required
+  - CKV_AWS_108 # IAM: only scan-website resources exist in the account
+  - CKV_AWS_109 # KMS: `resources=["*"]` references the key the policy is attached to
+  - CKV_AWS_111 # MKS: `resources=["*"]` references the key the policy is attached to
+  - CKV_AWS_115 # Lambda: function-level concurrent execution limit not required
+  - CKV_AWS_116 # Lambda: Dead Letter Queue not required
+  - CKV_AWS_117 # Lambda: access to VPC resources not required
+  - CKV_AWS_120 # API Gateway: caching is not wanted
+  - CKV_AWS_136 # ECR: default encryption key is acceptable 
+  - CKV_AWS_158 # CloudWatch: default encryption key is acceptable
+  - CKV_AWS_173 # Lambda: environment variable encryption with default KMS key is acceptable
+  - CKV2_AWS_29 # API Gateway needs a WAF ACL.  This can be removed when #142 lands.

--- a/terragrunt/aws/api/api_gateway.tf
+++ b/terragrunt/aws/api/api_gateway.tf
@@ -39,6 +39,17 @@ resource "aws_api_gateway_method" "method" {
   }
 }
 
+resource "aws_api_gateway_method_settings" "all" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  stage_name  = aws_api_gateway_stage.api.stage_name
+  method_path = "*/*"
+
+  settings {
+    metrics_enabled = true
+    logging_level   = "ERROR"
+  }
+}
+
 resource "aws_api_gateway_method_response" "api_response_200" {
   rest_api_id = aws_api_gateway_rest_api.api.id
   resource_id = aws_api_gateway_resource.resource.id
@@ -79,7 +90,6 @@ resource "aws_api_gateway_integration_response" "integration_response" {
   }
 }
 
-# checkov:skip=CKV_AWS_59:Serving publiclicy accessible content
 resource "aws_api_gateway_method" "root_method" {
   rest_api_id   = aws_api_gateway_rest_api.api.id
   resource_id   = aws_api_gateway_rest_api.api.root_resource_id
@@ -143,4 +153,9 @@ resource "aws_api_gateway_stage" "api" {
   deployment_id = aws_api_gateway_deployment.api.id
   rest_api_id   = aws_api_gateway_rest_api.api.id
   stage_name    = "v1"
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_access.arn
+    format          = "{\"requestId\":\"$context.requestId\", \"ip\": \"$context.identity.sourceIp\", \"caller\":\"$context.identity.caller\", \"requestTime\":\"$context.requestTime\", \"httpMethod\":\"$context.httpMethod\", \"resourcePath\":\"$context.resourcePath\", \"status\":\"$context.status\", \"responseLength\":\"$context.responseLength\"}"
+  }
 }

--- a/terragrunt/aws/api/cloudwatch.tf
+++ b/terragrunt/aws/api/cloudwatch.tf
@@ -1,0 +1,39 @@
+#
+# API Gateway CloudWatch logging
+#
+resource "aws_cloudwatch_log_group" "api_access" {
+  name              = "/aws/api-gateway/api-access"
+  retention_in_days = 14
+
+  tags = {
+    CostCenter = var.billing_code
+  }
+}
+
+# This account will be used by all API Gateway resources in the account and region
+resource "aws_api_gateway_account" "api_cloudwatch" {
+  cloudwatch_role_arn = aws_iam_role.api_cloudwatch.arn
+}
+
+resource "aws_iam_role" "api_cloudwatch" {
+  name               = "ApiGatewayCloudWatchRole"
+  assume_role_policy = data.aws_iam_policy_document.api_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "api_cloudwatch" {
+  role       = aws_iam_role.api_cloudwatch.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+}
+
+data "aws_iam_policy_document" "api_assume" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["apigateway.amazonaws.com"]
+    }
+  }
+}

--- a/terragrunt/aws/api/ecr.tf
+++ b/terragrunt/aws/api/ecr.tf
@@ -1,6 +1,4 @@
 resource "aws_ecr_repository" "api" {
-  # checkov:skip=CKV_AWS_51:The :latest tag is used in Staging
-
   name                 = "${var.product_name}/api"
   image_tag_mutability = "MUTABLE"
 

--- a/terragrunt/aws/api/kms.tf
+++ b/terragrunt/aws/api/kms.tf
@@ -1,6 +1,3 @@
-
-data "aws_caller_identity" "current" {}
-
 data "aws_iam_policy_document" "kms_policies" {
 
   statement {
@@ -17,7 +14,7 @@ data "aws_iam_policy_document" "kms_policies" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+      identifiers = ["arn:aws:iam::${var.account_id}:root"]
     }
   }
   statement {
@@ -38,7 +35,7 @@ data "aws_iam_policy_document" "kms_policies" {
 
     principals {
       type        = "Service"
-      identifiers = ["logs.ca-central-1.amazonaws.com"]
+      identifiers = ["logs.${var.region}.amazonaws.com"]
     }
   }
 

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -22,6 +22,10 @@ resource "aws_lambda_function" "api" {
     }
   }
 
+  tracing_config {
+    mode = "PassThrough"
+  }
+
   vpc_config {
     security_group_ids = [module.rds.proxy_security_group_id, aws_security_group.api.id]
     subnet_ids         = module.vpc.private_subnet_ids

--- a/terragrunt/aws/scanners/axe-core/ecr.tf
+++ b/terragrunt/aws/scanners/axe-core/ecr.tf
@@ -1,6 +1,4 @@
 resource "aws_ecr_repository" "scanners-axe-core" {
-  # checkov:skip=CKV_AWS_51:The :latest tag is used in Staging
-
   name                 = "${var.product_name}/scanners/axe-core"
   image_tag_mutability = "MUTABLE"
 

--- a/terragrunt/aws/scanners/axe-core/iam.tf
+++ b/terragrunt/aws/scanners/axe-core/iam.tf
@@ -28,7 +28,7 @@ resource "aws_iam_role_policy_attachment" "lambda_insights" {
 data "aws_iam_policy_document" "api_policies" {
 
   statement {
-
+    sid    = "CloudWatchAccess"
     effect = "Allow"
 
     actions = [
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "api_policies" {
   }
 
   statement {
-
+    sid    = "ECRImageAccess"
     effect = "Allow"
 
     actions = [
@@ -56,7 +56,7 @@ data "aws_iam_policy_document" "api_policies" {
   }
 
   statement {
-
+    sid    = "S3BucketAccess"
     effect = "Allow"
 
     actions = [

--- a/terragrunt/aws/scanners/axe-core/lambda.tf
+++ b/terragrunt/aws/scanners/axe-core/lambda.tf
@@ -9,6 +9,10 @@ resource "aws_lambda_function" "scanners-axe-core" {
 
   memory_size = 1600
 
+  tracing_config {
+    mode = "PassThrough"
+  }
+
   environment {
     variables = {
       REPORT_DATA_BUCKET = var.axe_core_report_data_bucket_id

--- a/terragrunt/aws/scanners/owasp-zap/ecr.tf
+++ b/terragrunt/aws/scanners/owasp-zap/ecr.tf
@@ -1,6 +1,4 @@
 resource "aws_ecr_repository" "scanners-owasp-zap" {
-  # checkov:skip=CKV_AWS_51:The :latest tag is used in Staging
-
   name                 = "${var.product_name}/scanners/owasp-zap"
   image_tag_mutability = "MUTABLE"
 
@@ -10,8 +8,6 @@ resource "aws_ecr_repository" "scanners-owasp-zap" {
 }
 
 resource "aws_ecr_repository" "runners-owasp-zap" {
-  # checkov:skip=CKV_AWS_51:The :latest tag is used in Staging
-
   name                 = "${var.product_name}/runners/owasp-zap"
   image_tag_mutability = "MUTABLE"
 

--- a/terragrunt/aws/scanners/owasp-zap/ecs.tf
+++ b/terragrunt/aws/scanners/owasp-zap/ecs.tf
@@ -25,7 +25,6 @@ resource "aws_ecs_task_definition" "runners-owasp-zap" {
 }
 
 resource "aws_cloudwatch_log_group" "log" {
-  # checkov:skip=CKV_AWS_158:Encryption using default CloudWatch service key is acceptable
   name              = "/aws/ecs/runners_owasp_zap_ecs"
   retention_in_days = 14
 }

--- a/terragrunt/aws/scanners/owasp-zap/lambda.tf
+++ b/terragrunt/aws/scanners/owasp-zap/lambda.tf
@@ -1,6 +1,4 @@
 resource "aws_lambda_function" "scanners-owasp-zap" {
-  # checkov:skip=CKV_AWS_50:X-ray tracing only required during function debug
-  # checkov:skip=CKV_AWS_115:Reserved concurrency not required (not latency sensitive)
   function_name = "scanners-owasp-zap"
 
   package_type = "Image"
@@ -10,6 +8,10 @@ resource "aws_lambda_function" "scanners-owasp-zap" {
   timeout = 60
 
   memory_size = 1024
+
+  tracing_config {
+    mode = "PassThrough"
+  }
 
   environment {
     variables = {


### PR DESCRIPTION
# Summary
This includes the following fixes:

* enable API gateway access logs
* enable Lambda X-ray tracing for debug
* use common Terragrunt vars for KMS policy
* add IAM policy `sid` to stop policy flapping in plans

The last outstanding warning for a WAF ACL will be handled by #142.

Closes #132
