### PR TITLE
feat: add WAF ACL for API

### DIFF
--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -12,4 +12,3 @@ skip-check:
   - CKV_AWS_136 # ECR: default encryption key is acceptable 
   - CKV_AWS_158 # CloudWatch: default encryption key is acceptable
   - CKV_AWS_173 # Lambda: environment variable encryption with default KMS key is acceptable
-  - CKV2_AWS_29 # API Gateway needs a WAF ACL.  This can be removed when #142 lands.

--- a/terragrunt/aws/api/api_gateway.tf
+++ b/terragrunt/aws/api/api_gateway.tf
@@ -150,6 +150,7 @@ resource "aws_api_gateway_deployment" "api" {
 }
 
 resource "aws_api_gateway_stage" "api" {
+  # checkov:skip=CKV2_AWS_29: False-positive, API stage is associated with WAF ACL in ./waf.tf
   deployment_id = aws_api_gateway_deployment.api.id
   rest_api_id   = aws_api_gateway_rest_api.api.id
   stage_name    = "v1"

--- a/terragrunt/aws/api/waf.tf
+++ b/terragrunt/aws/api/waf.tf
@@ -1,0 +1,157 @@
+resource "aws_wafv2_web_acl" "api_waf" {
+  name        = "api_waf"
+  description = "WAF for API protection"
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWSManagedRulesAmazonIpReputationList"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 2
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        excluded_rule {
+          name = "GenericRFI_BODY"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 3
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesKnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesLinuxRuleSet"
+    priority = 4
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesLinuxRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesLinuxRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesSQLiRuleSet"
+    priority = 5
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesSQLiRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesSQLiRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "api_rate_limit"
+    priority = 101
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 100
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "api_rate_limit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "api"
+    sampled_requests_enabled   = false
+  }
+}
+
+
+resource "aws_wafv2_web_acl_association" "waf_association" {
+  resource_arn = aws_api_gateway_stage.api.arn
+  web_acl_arn  = aws_wafv2_web_acl.api_waf.arn
+}


### PR DESCRIPTION
# Summary
Associate a Web Application Firewall Access Control List with
the API to protect it from malicious input.

Also provides a rate limit of 100 requests from the same IP in a
5 minute period (the minimum allowed by a rate limit statement).
If these needs to be lower, we can add multiple rate limit statements.

Related #111
Closes #142
