### PR TITLE
fix: remove slowapi rate limiting

### DIFF
--- a/api/api_gateway/routers/scans.py
+++ b/api/api_gateway/routers/scans.py
@@ -10,8 +10,6 @@ from fastapi import (
 from logger import log
 from pydantic import BaseModel
 from crawler.crawler import crawl
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
@@ -26,7 +24,6 @@ from models.ScanType import ScanType
 from schemas.Template import TemplateCreate, TemplateScanCreateList
 
 
-limiter = Limiter(key_func=get_remote_address, enabled=True)
 router = APIRouter()
 
 
@@ -57,7 +54,6 @@ def template_belongs_to_org(
 
 
 @router.post("/crawl")
-@limiter.limit("5/minute")
 def crawl_endpoint(
     crawl_url: CrawlUrl, background_tasks: BackgroundTasks, request: Request
 ):

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -16,4 +16,3 @@ python-multipart==0.0.5
 SQLAlchemy==1.4.22
 scrapy==2.5.0
 scrapy-playwright==0.0.4
-slowapi==0.1.5

--- a/api/tests/api_gateway/test_api.py
+++ b/api/tests/api_gateway/test_api.py
@@ -67,23 +67,6 @@ def test_crawl(mock_uuid, mock_log, mock_crawl):
     mock_log.info.assert_called_once_with("Crawling url='bar'")
 
 
-@patch("api_gateway.routers.scans.crawl")
-@patch("api_gateway.routers.scans.log")
-@patch("api_gateway.routers.scans.uuid")
-def test_crawl_ratelimit(mock_uuid, mock_log, mock_crawl):
-    fake_url = "bar"
-    fake_uuid = "foo"
-    mock_log.return_value = None
-    mock_uuid.uuid4.return_value = fake_uuid
-
-    for i in range(0, 10):
-        response = client.post(url="/scans/crawl", json={"url": fake_url})
-        if i < 4:
-            assert response.status_code == 200
-        else:
-            assert response.status_code == 429
-
-
 def test_accessing_protected_route_not_logged_in():
     fresh_client = TestClient(api.app)
     response = fresh_client.get("/me")


### PR DESCRIPTION
# Summary
IP based rate limiting has been added by the WAF ACL in #144.

Closes #111 
