### PR TITLE
fix: topic arn and unblock url when creating scans

### DIFF
--- a/.github/workflows/tf_plan.yml
+++ b/.github/workflows/tf_plan.yml
@@ -47,7 +47,7 @@ jobs:
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
 
       - name: Terraform plan
-        uses: cds-snc/terraform-plan@v1
+        uses: cds-snc/terraform-plan@v1.0.11
         with:
           comment-delete: true
           comment-title: Plan for ${{ matrix.module }}

--- a/.github/workflows/tf_plan.yml
+++ b/.github/workflows/tf_plan.yml
@@ -11,6 +11,7 @@ env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 1.0.3
   TERRAGRUNT_VERSION: v0.31.1
+  CONFTEST_VERSION: 0.27.0
   TF_VAR_rds_password: ${{ secrets.TF_VARS_RDS_PASSWORD }}
   TF_VAR_fastapi_secret_key: ${{ secrets.TF_VARS_FASTAPI_SECRET_KEY }}
   TF_VAR_google_client_id: ${{ secrets.TF_VARS_GOOGLE_CLIENT_ID }}
@@ -38,6 +39,14 @@ jobs:
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
+      - name: Install Conftest
+        run: |
+          wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" \
+          && wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/checksums.txt" \
+          && grep 'Linux_x86_64.tar.gz' < checksums.txt | sha256sum --check  --status \
+          && tar -zxvf "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" conftest \
+          && mv conftest /usr/local/bin \
+          && rm "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" checksums.txt
 
       - name: Setup Terragrunt
         run: |
@@ -47,7 +56,7 @@ jobs:
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
 
       - name: Terraform plan
-        uses: cds-snc/terraform-plan@v1.0.11
+        uses: cds-snc/terraform-plan@v1
         with:
           comment-delete: true
           comment-title: Plan for ${{ matrix.module }}

--- a/.github/workflows/tf_plan.yml
+++ b/.github/workflows/tf_plan.yml
@@ -56,7 +56,7 @@ jobs:
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
 
       - name: Terraform plan
-        uses: cds-snc/terraform-plan@v1
+        uses: cds-snc/terraform-plan@v2
         with:
           comment-delete: true
           comment-title: Plan for ${{ matrix.module }}

--- a/api/api_gateway/routers/scans.py
+++ b/api/api_gateway/routers/scans.py
@@ -15,6 +15,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 import json
+import os
 import uuid
 from typing import Optional
 
@@ -128,7 +129,9 @@ def start_scan(
                     item["url"] = entry["url"]
                 if "revision" in entry:
                     item["revision"] = entry["revision"]
-            item["queue"] = template_scan.scan_type.callback["topic_env"]
+            item["queue"] = os.getenv(
+                template_scan.scan_type.callback["topic_env"], "NOT_FOUND"
+            )
 
         if "url" not in item:
             return {"message": "Scan error: URL not configured in template"}

--- a/api/tests/api_gateway/test_scans.py
+++ b/api/tests/api_gateway/test_scans.py
@@ -2,8 +2,9 @@ from fastapi.testclient import TestClient
 from unittest.mock import ANY, MagicMock, patch
 
 from api_gateway import api
-
 from pub_sub import pub_sub
+
+import os
 
 client = TestClient(api.app)
 
@@ -177,6 +178,7 @@ def test_start_scan_valid_api_keys(
 
 @patch("pub_sub.pub_sub.send")
 @patch("database.db.get_session")
+@patch.dict(os.environ, {"OWASP_ZAP_URLS_TOPIC": "topic"}, clear=True)
 def test_start_scan_valid_api_keys_with_gitsha(
     mock_db_session,
     mock_send,
@@ -196,7 +198,7 @@ def test_start_scan_valid_api_keys_with_gitsha(
     assert response.status_code == 200
 
     mock_send.assert_called_once_with(
-        "OWASP_ZAP_URLS_TOPIC",
+        "topic",
         {
             "type": pub_sub.AvailableScans.OWASP_ZAP.value,
             "product": home_org_owasp_zap_template_fixture.name,
@@ -205,7 +207,7 @@ def test_start_scan_valid_api_keys_with_gitsha(
             "scan_id": ANY,
             "url": "https://www.alpha.canada.ca",
             "event": "sns",
-            "queue": "OWASP_ZAP_URLS_TOPIC",
+            "queue": "topic",
             "id": ANY,
         },
     )


### PR DESCRIPTION
Topic arn was not being retrieved from environment variable and currently getting block by RFI_BODY WAF rule when creating new scans.