### PR TITLE
feat: allow api to decrypt kms used for sns topics

### DIFF
--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -81,6 +81,11 @@ resource "aws_iam_role_policy_attachment" "api" {
   policy_arn = aws_iam_policy.api.arn
 }
 
+resource "aws_iam_role_policy_attachment" "kms" {
+  role       = aws_iam_role.api.name
+  policy_arn = aws_iam_policy.kms.arn
+}
+
 # Use AWS managed IAM policy
 ####
 # Provides minimum permissions for a Lambda function to execute while

--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -68,6 +68,17 @@ data "aws_iam_policy_document" "api_policies" {
     ]
   }
 
+  statement {
+
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*"
+    ]
+
+    resources = [aws_kms_key.scan-websites.arn]
+  }
 }
 
 resource "aws_iam_policy" "api" {
@@ -79,11 +90,6 @@ resource "aws_iam_policy" "api" {
 resource "aws_iam_role_policy_attachment" "api" {
   role       = aws_iam_role.api.name
   policy_arn = aws_iam_policy.api.arn
-}
-
-resource "aws_iam_role_policy_attachment" "kms" {
-  role       = aws_iam_role.api.name
-  policy_arn = aws_iam_policy.kms.arn
 }
 
 # Use AWS managed IAM policy

--- a/terragrunt/aws/api/kms.tf
+++ b/terragrunt/aws/api/kms.tf
@@ -70,9 +70,3 @@ resource "aws_kms_key" "scan-websites" {
     CostCenter = var.billing_code
   }
 }
-
-resource "aws_iam_policy" "kms" {
-  name   = "${var.product_name}-kms"
-  path   = "/"
-  policy = data.aws_iam_policy_document.kms_policies.json
-}

--- a/terragrunt/aws/api/kms.tf
+++ b/terragrunt/aws/api/kms.tf
@@ -70,3 +70,9 @@ resource "aws_kms_key" "scan-websites" {
     CostCenter = var.billing_code
   }
 }
+
+resource "aws_iam_policy" "kms" {
+  name   = "${var.product_name}-kms"
+  path   = "/"
+  policy = data.aws_iam_policy_document.kms_policies.json
+}


### PR DESCRIPTION
Grant the API access to kms in-order to publish to encrypted sns topic. Applied locally to test