### PR TITLE
fix: schema validation and WAF regex

### DIFF
--- a/api/front_end/view.py
+++ b/api/front_end/view.py
@@ -274,11 +274,12 @@ async def template_scan(
             if template_scan.id == template_scan_id:
                 return_template_scan = template_scan
                 for key, value in template_scan.data.items():
-                    scan_configs.append(
-                        TemplateScanConfigData(
-                            id=str(uuid.uuid4()), key=key, value=value
+                    if value is not None:
+                        scan_configs.append(
+                            TemplateScanConfigData(
+                                id=str(uuid.uuid4()), key=key, value=value
+                            )
                         )
-                    )
 
         result = {"request": request}
         result.update(languages[locale])

--- a/terragrunt/aws/api/waf.tf
+++ b/terragrunt/aws/api/waf.tf
@@ -195,7 +195,7 @@ resource "aws_wafv2_regex_pattern_set" "body_exclusions" {
   scope       = "REGIONAL"
 
   regular_expression {
-    regex_string = "^/scans/template/.+/scan$"
+    regex_string = "^/scans/template/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}/(scan|scan/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12})$"
   }
 }
 


### PR DESCRIPTION
Remove all schema data attributes that automagically add a `None`. Also expands the WAF rules to include exceptions PU requests for template scan updates.