### PR TITLE
fix: set playwright path

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -37,6 +37,7 @@ WORKDIR ${FUNCTION_DIR}
 
 RUN mkdir -p /pymodules
 ENV PYTHONPATH=/pymodules
+ENV PLAYWRIGHT_BROWSERS_PATH=0
 
 COPY ./requirements_playwright.txt ${FUNCTION_DIR}
 


### PR DESCRIPTION
This PR sets a playwright path in the API docker build. When the image is built chromium is installed in a different path than it can be accessed by the user executing the lambda. This should create a hermetic build.