### PR TITLE
feat: delete associated scans when template deleted

### DIFF
--- a/api/api_gateway/routers/scans.py
+++ b/api/api_gateway/routers/scans.py
@@ -279,7 +279,18 @@ async def delete_template_scan(
             )
             .one()
         )
+
+        scan = (
+            session.query(Scan)
+            .filter(
+                Scan.scan_type_id == template_scan.scan_type_id,
+                Scan.template_id == template_scan.template_id,
+            )
+            .one_or_none()
+        )
         session.delete(template_scan)
+        if scan is not None:
+            session.delete(scan)
         session.commit()
         return {"status": "OK"}
 

--- a/api/db_migrations/versions/ee2ca4ffaee4_cleanup_orphaned_scans.py
+++ b/api/db_migrations/versions/ee2ca4ffaee4_cleanup_orphaned_scans.py
@@ -1,0 +1,25 @@
+"""cleanup orphaned scans
+
+Revision ID: ee2ca4ffaee4
+Revises: 9cceeaa52f49
+Create Date: 2021-10-14 13:44:27.460893
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "ee2ca4ffaee4"
+down_revision = "9cceeaa52f49"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """DELETE FROM "scans" s WHERE NOT EXISTS (SELECT NULL FROM "template_scans" ts WHERE ts.scan_type_id = s.scan_type_id AND ts.template_id = s.template_id); """
+    )
+
+
+def downgrade():
+    pass

--- a/api/front_end/templates/index.html
+++ b/api/front_end/templates/index.html
@@ -15,9 +15,11 @@
             {% if scan.security_reports %}
             <div class="relative flex-1 flex flex-col gap-2 px-4">
                 <h3 class="text-gray-800 text-base font-semibold tracking-wider">
-                  <a href="/{{ lang }}/results/{{ template.id }}/scan/{{ scan.id }}">
-                    {{ scan.scan_type.name }}
-                  </a>
+                  {% if request.session.user is not defined %}
+                  <span>{{ scan.scan_type.name }}</span>
+                  {% else %}
+                  <a href="/{{ lang }}/results/{{ template.id }}/scan/{{ scan.id }}">{{ scan.scan_type.name }}</a>
+                  {% endif %}
                 </h3>
                 <div class="container flex flex-row gap-1 mx-8">
                   <div class="relative flex-1 flex flex-col gap-2 px-1">
@@ -45,9 +47,11 @@
             {% if scan.a11y_reports %}
             <div class="relative flex-1 flex flex-col gap-2 px-4">
               <div class="text-gray-800 text-base font-semibold tracking-wider">
-                <a href="/{{ lang }}/results/{{ template.id }}/scan/{{ scan.id }}">
-                  {{ scan.scan_type.name }}
-                </a>
+                {% if request.session.user is not defined %}
+                <span>{{ scan.scan_type.name }}</span>
+                {% else %}
+                <a href="/{{ lang }}/results/{{ template.id }}/scan/{{ scan.id }}">{{ scan.scan_type.name }}</a>
+                {% endif %}
               </div>
                 <div class="container flex flex-row gap-1 mx-8">
                   <div class="relative flex-1 flex flex-col gap-2 px-1">

--- a/api/models/Scan.py
+++ b/api/models/Scan.py
@@ -42,5 +42,11 @@ class Scan(Base):
     )
     scan_type = relationship("ScanType", back_populates="scans")
 
-    a11y_reports = relationship("A11yReport", cascade="all,delete")
-    security_reports = relationship("SecurityReport", cascade="all,delete")
+    a11y_reports = relationship(
+        "A11yReport", cascade="all,delete", order_by="desc(A11yReport.updated_at)"
+    )
+    security_reports = relationship(
+        "SecurityReport",
+        cascade="all,delete",
+        order_by="desc(SecurityReport.updated_at)",
+    )

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -92,7 +92,7 @@ def owasp_security_report_fixture(session, home_org_owasp_scan_fixture):
 
 
 @pytest.fixture(scope="session")
-def home_org_security_violation_fixture(session, owasp_security_report_fixture):
+def owasp_security_violation_fixture(session, owasp_security_report_fixture):
     security_violation = SecurityViolation(
         violation="violation",
         risk="risk",
@@ -103,6 +103,38 @@ def home_org_security_violation_fixture(session, owasp_security_report_fixture):
         tags="tags",
         url="url",
         security_report=owasp_security_report_fixture,
+    )
+    session.add(security_violation)
+    session.commit()
+    return security_violation
+
+
+@pytest.fixture(scope="session")
+def home_org_security_report_fixture(session, home_org_scan_fixture):
+    security_report = SecurityReport(
+        product="product",
+        revision="revision",
+        url="url",
+        summary={"jsonb": "data"},
+        scan=home_org_scan_fixture,
+    )
+    session.add(security_report)
+    session.commit()
+    return security_report
+
+
+@pytest.fixture(scope="session")
+def home_org_security_violation_fixture(session, home_org_security_report_fixture):
+    security_violation = SecurityViolation(
+        violation="violation",
+        risk="risk",
+        confidence="confidence",
+        solution="solution",
+        reference="reference",
+        data=[{"uri": "https://example.com/", "method": "POST", "evidence": "foo"}],
+        tags="tags",
+        url="url",
+        security_report=home_org_security_report_fixture,
     )
     session.add(security_violation)
     session.commit()
@@ -172,6 +204,23 @@ def scan_fixture(scan_type_fixture, template_fixture, organisation_fixture, sess
         organisation=organisation_fixture,
         scan_type=scan_type_fixture,
         template=template_fixture,
+    )
+    session.add(scan)
+    session.commit()
+    return scan
+
+
+@pytest.fixture(scope="session")
+def home_org_scan_fixture(
+    owasp_zap_fixture,
+    home_org_template_fixture,
+    home_organisation_fixture,
+    session,
+):
+    scan = Scan(
+        organisation=home_organisation_fixture,
+        scan_type=owasp_zap_fixture,
+        template=home_org_template_fixture,
     )
     session.add(scan)
     session.commit()
@@ -266,6 +315,20 @@ def home_org_template_scan_fixture(
     template_scan = TemplateScan(
         data={"jsonb": "data"},
         scan_type=scan_type_fixture,
+        template=home_org_template_fixture,
+    )
+    session.add(template_scan)
+    session.commit()
+    return template_scan
+
+
+@pytest.fixture(scope="session")
+def home_org_template_scan_fixture_with_zap(
+    owasp_zap_fixture, home_org_template_fixture, session
+):
+    template_scan = TemplateScan(
+        data={"url": "https://www.alpha.canada.ca"},
+        scan_type=owasp_zap_fixture,
         template=home_org_template_fixture,
     )
     session.add(template_scan)


### PR DESCRIPTION
- Alembic script to cleanup orphaned scans
- Remove view scan link for unauthenticed users
- Delete template scan endpoint will now delete associated scans
- A11yReport and SecurityReports are now sorted by update timestamp descending