### PR TITLE
fix: provide chrome args for playwright

### DIFF
--- a/api/crawler/crawler.py
+++ b/api/crawler/crawler.py
@@ -53,6 +53,33 @@ def runner(item):
                 "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
                 "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
             },
+            "PLAYWRIGHT_LAUNCH_OPTIONS": {
+                "args": [
+                    "--allow-running-insecure-content",
+                    "--autoplay-policy=user-gesture-required",
+                    "--disable-component-update",
+                    "--disable-domain-reliability",
+                    "--disable-features=AudioServiceOutOfProcess,IsolateOrigins,site-per-process",
+                    "--disable-print-preview",
+                    "--disable-setuid-sandbox",
+                    "--disable-site-isolation-trials",
+                    "--disable-speech-api",
+                    "--disable-web-security",
+                    "--disk-cache-size=33554432",
+                    "--enable-features=SharedArrayBuffer",
+                    "--hide-scrollbars",
+                    "--ignore-gpu-blocklist",
+                    "--in-process-gpu",
+                    "--mute-audio",
+                    "--no-default-browser-check",
+                    "--no-pings",
+                    "--no-sandbox",
+                    "--no-zygote",
+                    "--use-gl=swiftshader",
+                    "--window-size=1920,1080",
+                    "--single-process",
+                ]
+            },
         }
     )
     runner.crawl(UrlSpider, item)

--- a/api/tests/crawler/test_crawler.py
+++ b/api/tests/crawler/test_crawler.py
@@ -50,6 +50,33 @@ def test_crawl_runner_calls_spider(mock_cawler_class):
                 "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
                 "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
             },
+            "PLAYWRIGHT_LAUNCH_OPTIONS": {
+                "args": [
+                    "--allow-running-insecure-content",
+                    "--autoplay-policy=user-gesture-required",
+                    "--disable-component-update",
+                    "--disable-domain-reliability",
+                    "--disable-features=AudioServiceOutOfProcess,IsolateOrigins,site-per-process",
+                    "--disable-print-preview",
+                    "--disable-setuid-sandbox",
+                    "--disable-site-isolation-trials",
+                    "--disable-speech-api",
+                    "--disable-web-security",
+                    "--disk-cache-size=33554432",
+                    "--enable-features=SharedArrayBuffer",
+                    "--hide-scrollbars",
+                    "--ignore-gpu-blocklist",
+                    "--in-process-gpu",
+                    "--mute-audio",
+                    "--no-default-browser-check",
+                    "--no-pings",
+                    "--no-sandbox",
+                    "--no-zygote",
+                    "--use-gl=swiftshader",
+                    "--window-size=1920,1080",
+                    "--single-process",
+                ]
+            },
         }
     )
     mock_runner.crawl.assert_called_once_with(crawler.UrlSpider, item)


### PR DESCRIPTION
Adds the known set of working chromium flags that seem to work on Lambda