### PR TITLE
feat: add CloudWatch Alarm Slack notifications

### DIFF
--- a/.github/workflows/tf_apply.yml
+++ b/.github/workflows/tf_apply.yml
@@ -12,6 +12,7 @@ env:
   TF_VAR_fastapi_secret_key: ${{ secrets.TF_VARS_FASTAPI_SECRET_KEY }}
   TF_VAR_google_client_id: ${{ secrets.TF_VARS_GOOGLE_CLIENT_ID }}
   TF_VAR_google_client_secret: ${{ secrets.TF_VARS_GOOGLE_CLIENT_SECRET }}
+  TF_VAR_slack_webhook_url: ${{ secrets.TF_VARS_SLACK_WEBHOOK_URL }}
 
 jobs:
   terragrunt-apply:
@@ -42,12 +43,15 @@ jobs:
         id: filter
         with:
           filters: |
+            alarms:
+              - 'terragrunt/aws/alarms/**'
+              - 'terragrunt/env/alarms/**'
             api:
               - 'terragrunt/aws/api/**'
               - 'terragrunt/env/api/**'
             hosted_zone:
               - 'terragrunt/aws/hosted_zone/**'
-              - 'terragrunt/env/hosted_zone/**'              
+              - 'terragrunt/env/hosted_zone/**'
             scanners-axe-core:
               - 'terragrunt/aws/scanners/axe-core/**'
               - 'terragrunt/env/scanners/axe-core/**'
@@ -55,17 +59,23 @@ jobs:
               - 'terragrunt/aws/scanners/owasp-zap/**'
               - 'terragrunt/env/scanners/owasp-zap/**'
 
+      - name: Apply hosted_zone
+        if: ${{ steps.filter.outputs.hosted_zone == 'true' }}
+        working-directory: terragrunt/env/hosted_zone
+        run: |
+          terragrunt apply --terragrunt-non-interactive -auto-approve
+
       - name: Apply api
         if: ${{ steps.filter.outputs.api == 'true' }}
         working-directory: terragrunt/env/api
         run: |
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
-      - name: Apply hosted_zone
-        if: ${{ steps.filter.outputs.hosted_zone == 'true' }}
-        working-directory: terragrunt/env/hosted_zone
+      - name: Apply alarms
+        if: ${{ steps.filter.outputs.alarms == 'true' }}
+        working-directory: terragrunt/env/alarms
         run: |
-          terragrunt apply --terragrunt-non-interactive -auto-approve      
+          terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Apply scanners/axe-core
         if: ${{ steps.filter.outputs.scanners-axe-core == 'true' }}

--- a/.github/workflows/tf_plan.yml
+++ b/.github/workflows/tf_plan.yml
@@ -16,6 +16,7 @@ env:
   TF_VAR_fastapi_secret_key: ${{ secrets.TF_VARS_FASTAPI_SECRET_KEY }}
   TF_VAR_google_client_id: ${{ secrets.TF_VARS_GOOGLE_CLIENT_ID }}
   TF_VAR_google_client_secret: ${{ secrets.TF_VARS_GOOGLE_CLIENT_SECRET }}
+  TF_VAR_slack_webhook_url: ${{ secrets.TF_VARS_SLACK_WEBHOOK_URL }}
 
 
 jobs:
@@ -24,6 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - module: alarms
           - module: api
           - module: hosted_zone
           - module: scanners/axe-core

--- a/terragrunt/aws/alarms/cloudwatch_breakglass.tf
+++ b/terragrunt/aws/alarms/cloudwatch_breakglass.tf
@@ -3,8 +3,7 @@ module "ops_alarms" {
   account_names         = ["ops1", "ops2"]
   namespace             = "ops_alarms"
   log_group_name        = "CloudTrail/Landing-Zone-Logs"
-  alarm_actions_success = [aws_sns_topic.critical.arn]
-  alarm_actions_failure = [aws_sns_topic.warning.arn]
+  alarm_actions_success = [var.sns_topic_critical_arn]
+  alarm_actions_failure = [var.sns_topic_warning_arn]
   num_attempts          = 1
 }
-

--- a/terragrunt/aws/alarms/cloudwatch_lambda.tf
+++ b/terragrunt/aws/alarms/cloudwatch_lambda.tf
@@ -1,0 +1,15 @@
+resource "aws_cloudwatch_metric_alarm" "lambda_concurrent_executions" {
+  alarm_name          = "LambdaConcurrentExecutions"
+  alarm_description   = "Average number of concurrent Lambda invocations in a 1 minute period."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ConcurrentExecutions"
+  namespace           = "AWS/Lambda"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = var.lambda_concurrent_executions
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.sns_topic_warning_arn]
+  ok_actions    = [var.sns_topic_warning_arn]
+}

--- a/terragrunt/aws/alarms/inputs.tf
+++ b/terragrunt/aws/alarms/inputs.tf
@@ -1,0 +1,20 @@
+variable "lambda_concurrent_executions" {
+  description = "Threshold of Lambda concurrent executions before an alarm is triggered"
+  type        = number
+}
+
+variable "slack_webhook_url" {
+  description = "Slack incoming webhook URL to post the alarm notifications to"
+  type        = string
+  sensitive   = true
+}
+
+variable "sns_topic_critical_arn" {
+  description = "Critical SNS Topic ARN"
+  type        = string
+}
+
+variable "sns_topic_warning_arn" {
+  description = "Warning SNS Topic ARN"
+  type        = string
+}

--- a/terragrunt/aws/alarms/notify_slack.tf
+++ b/terragrunt/aws/alarms/notify_slack.tf
@@ -1,0 +1,30 @@
+#
+# Lambda: post notifications to Slack
+#
+module "notify_slack" {
+  source = "github.com/cds-snc/terraform-modules?ref=v0.0.36//notify_slack"
+
+  function_name     = "notify_slack"
+  project_name      = "Scan Websites"
+  slack_webhook_url = var.slack_webhook_url
+
+  sns_topic_arns = [
+    var.sns_topic_warning_arn,
+    var.sns_topic_critical_arn
+  ]
+
+  billing_tag_key   = "CostCenter"
+  billing_tag_value = var.billing_code
+}
+
+resource "aws_sns_topic_subscription" "warning" {
+  topic_arn = var.sns_topic_warning_arn
+  protocol  = "lambda"
+  endpoint  = module.notify_slack.lambda_arn
+}
+
+resource "aws_sns_topic_subscription" "critical" {
+  topic_arn = var.sns_topic_critical_arn
+  protocol  = "lambda"
+  endpoint  = module.notify_slack.lambda_arn
+}

--- a/terragrunt/aws/api/outputs.tf
+++ b/terragrunt/aws/api/outputs.tf
@@ -41,3 +41,11 @@ output "log_bucket_id" {
 output "domain_name" {
   value = aws_api_gateway_domain_name.api.domain_name
 }
+
+output "sns_topic_critical_arn" {
+  value = aws_sns_topic.critical.arn
+}
+
+output "sns_topic_warning_arn" {
+  value = aws_sns_topic.warning.arn
+}

--- a/terragrunt/env/alarms/terragrunt.hcl
+++ b/terragrunt/env/alarms/terragrunt.hcl
@@ -1,0 +1,27 @@
+terraform {
+  source = "../../aws//alarms"
+}
+
+dependencies {
+  paths = ["../api"]
+}
+
+dependency "api" {
+  config_path = "../api"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    sns_topic_critical_arn = ""
+    sns_topic_warning_arn  = ""
+  }
+}
+
+inputs = {
+  lambda_concurrent_executions = 700
+  sns_topic_critical_arn       = dependency.api.outputs.sns_topic_critical_arn
+  sns_topic_warning_arn        = dependency.api.outputs.sns_topic_warning_arn
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary
Creates a new `alarms` module that will contain CloudWatch
Alarms and the Lambda function responsible for posting the alarm
state changes to an ops Slack channel.

For consistency, the `ops` breakglass login alarms were moved
to the new module.

# Related

- Closes #154