### PR TITLE
fix: build order in docker file

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -39,15 +39,15 @@ RUN mkdir -p /pymodules
 ENV PYTHONPATH=/pymodules
 ENV PLAYWRIGHT_BROWSERS_PATH=/pymodules/playwright
 
-
 COPY ./requirements_playwright.txt ${FUNCTION_DIR}
 
 RUN python3.9 -m pip install -r ${FUNCTION_DIR}/requirements_playwright.txt
-RUN playwright install chromium
 
 COPY ./requirements.txt ${FUNCTION_DIR}
 
 RUN python3.9 -m pip install -r ${FUNCTION_DIR}/requirements.txt --target /pymodules
+
+RUN playwright install chromium
 
 # Install the runtime interface client
 RUN pip install --target /pymodules \


### PR DESCRIPTION
This PR hopefully fixes the crawling components by changing the build order in the docker file. It looks like depending on when you install chromium, it uses different version. 🤷 