### PR TITLE
feat: launch zap scan using fargate spot to save costs

### DIFF
--- a/scanners/owasp-zap/src/impl.test.ts
+++ b/scanners/owasp-zap/src/impl.test.ts
@@ -51,7 +51,7 @@ describe("Impl", () => {
       const response = await Impl(records, ecs);
 
       expect(ecs.runTask).toHaveBeenCalledWith({
-        launchType: "FARGATE",
+        launchType: "FARGATE_SPOT",
         cluster: process.env.CLUSTER,
         taskDefinition: process.env.TASK_DEF_ARN,
         overrides: {

--- a/scanners/owasp-zap/src/impl.ts
+++ b/scanners/owasp-zap/src/impl.ts
@@ -10,7 +10,7 @@ export async function Impl(
   try {
     await asyncForEach(records, async (record: Record) => {
       const params = {
-        launchType: "FARGATE",
+        launchType: "FARGATE_SPOT",
         cluster: process.env.CLUSTER,
         taskDefinition: process.env.TASK_DEF_ARN,
         overrides: {

--- a/terragrunt/aws/scanners/owasp-zap/ecs.tf
+++ b/terragrunt/aws/scanners/owasp-zap/ecs.tf
@@ -1,6 +1,8 @@
 resource "aws_ecs_cluster" "scanning_tools" {
   name = "scanning-tools"
 
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
   setting {
     name  = "containerInsights"
     value = "enabled"


### PR DESCRIPTION
Since ZAP scans are short lived tasks, fargate spot may be a better option which will also save us costs