### PR TITLE
fix: duplicate header

### DIFF
--- a/api/front_end/static/js/template_scan.js
+++ b/api/front_end/static/js/template_scan.js
@@ -47,10 +47,10 @@ function scanAdd() {
       span.innerHTML =
         '<button class="bg-red-500 hover:bg-red-700 text-white font-bold  px-2 rounded" type="button" id="addScanButton" class="btn btn-primary" onclick="scanClear();">Clear</button>';
 
-      var header_span = document.createElement("span");
-      header_span.innerHTML = "<strong>Selected scan type</strong></br>";
+      // var header_span = document.createElement("span");
+      // header_span.innerHTML = "<strong>Selected scan type</strong></br>";
 
-      container.appendChild(header_span);
+      //container.appendChild(header_span);
       container.appendChild(input);
       container.appendChild(span);
       container.appendChild(document.createElement("br"));

--- a/api/front_end/static/js/template_scan.js
+++ b/api/front_end/static/js/template_scan.js
@@ -47,10 +47,6 @@ function scanAdd() {
       span.innerHTML =
         '<button class="bg-red-500 hover:bg-red-700 text-white font-bold  px-2 rounded" type="button" id="addScanButton" class="btn btn-primary" onclick="scanClear();">Clear</button>';
 
-      // var header_span = document.createElement("span");
-      // header_span.innerHTML = "<strong>Selected scan type</strong></br>";
-
-      //container.appendChild(header_span);
       container.appendChild(input);
       container.appendChild(span);
       container.appendChild(document.createElement("br"));

--- a/api/front_end/templates/template_scan.html
+++ b/api/front_end/templates/template_scan.html
@@ -34,8 +34,9 @@
         {% else %}
         <form id="templateScan" name="templateScan" action="/scans/template/{{template.id}}/scan" method="POST">
         {% endif %}
+          <strong>Selected scan type</strong></br>
           <div id="container" class="border-double border-4 border-light-blue-500 ...">
-            <strong>Selected scan type</strong></br>
+            
             {% if template_scan %}
             <div id='child'>
               <input type="text" id="scanType-{{ template_scan.scan_type.id }}"name="scanType" value="{{ template_scan.scan_type.name }}" readonly class="bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500"></input>  


### PR DESCRIPTION
Closes #191 by moving the header out of the div. The original reason for implementing the header through JS was that when clicked clear, it would remove the header, but when you added the header through the add button, you got two headers.