### PR TITLE
fix: increase zap scanners ephemeral storage to 40 GB

### DIFF
--- a/terragrunt/env/scanners/owasp-zap/container-definitions/zap_runner.json
+++ b/terragrunt/env/scanners/owasp-zap/container-definitions/zap_runner.json
@@ -57,6 +57,7 @@
 		],
 		"cpu": 1024,
 		"environment": [],
+    "ephemeral_storage": 200,
 		"essential": true,
 		"image": "owasp/zap2docker-stable",
 		"linuxParameters": {

--- a/terragrunt/env/scanners/owasp-zap/container-definitions/zap_runner.json
+++ b/terragrunt/env/scanners/owasp-zap/container-definitions/zap_runner.json
@@ -57,7 +57,7 @@
 		],
 		"cpu": 1024,
 		"environment": [],
-    "ephemeral_storage": 200,
+		"ephemeral_storage": 200,
 		"essential": true,
 		"image": "owasp/zap2docker-stable",
 		"linuxParameters": {

--- a/terragrunt/env/scanners/owasp-zap/container-definitions/zap_runner.json
+++ b/terragrunt/env/scanners/owasp-zap/container-definitions/zap_runner.json
@@ -57,7 +57,7 @@
 		],
 		"cpu": 1024,
 		"environment": [],
-		"ephemeral_storage": 200,
+		"ephemeral_storage": 40,
 		"essential": true,
 		"image": "owasp/zap2docker-stable",
 		"linuxParameters": {


### PR DESCRIPTION
OWASP Zap is running out of disk space, which is currently set to the default ECS amount of 20GB. This PR will increase the zap task to 40GB in-order to avoid running into disk space issues when scanning larger webapps.