### PR TITLE
feat: Adds PR review apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To interact with aws localstack `use` laws
 
 ### Seed local database
 
-`python api/database/seed.py`
+`cd api && make seed`
 
 ### Example - List buckets
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev fmt install lint migrations test fmt-ci lint-ci build install-dev
+.PHONY: dev fmt install lint migrations test fmt-ci lint-ci build install-dev seed heroku-seed
 
 build: ;
 
@@ -7,6 +7,13 @@ dev:
 
 fmt:
 	black . $(ARGS)
+
+heroku-seed:
+	make install &&\
+	make migrations &&\
+	make seed
+
+heroku-run:
 
 install:
 	pip3 install --user -r requirements.txt
@@ -23,6 +30,9 @@ lint-ci:
 migrations:
 	cd db_migrations &&\
 	alembic upgrade head
+
+seed: 
+	python database/seed.py
 
 test:
 	FASTAPI_SECRET_KEY='e8cb82f5-b966-4496-b96e-8c021892e265' CI=True coverage run -m pytest -s -vv tests &&\

--- a/api/database/seed.py
+++ b/api/database/seed.py
@@ -21,6 +21,7 @@ from models.ScanType import ScanType  # noqa: E402
 from models.Template import Template  # noqa: E402
 from models.TemplateScan import TemplateScan  # noqa: E402
 from models.TemplateScanTrigger import TemplateScanTrigger  # noqa: E402
+from models.User import User  # noqa: E402
 from pub_sub import pub_sub  # noqa: E402
 from storage import storage  # noqa: E402
 
@@ -50,6 +51,8 @@ if __name__ == "__main__":
         .scalar()
     )
 
+    print("Deleting all previous data ...")
+
     session.query(A11yViolation).delete()
     session.query(A11yReport).delete()
     session.query(SecurityViolation).delete()
@@ -59,6 +62,15 @@ if __name__ == "__main__":
     session.query(TemplateScanTrigger).delete()
     session.query(TemplateScan).delete()
     session.query(Template).delete()
+    session.query(User).delete()
+
+    print("Adding new data ...")
+
+    user = User(
+        name="Seed User",
+        email_address="scan-websites+seed@cds-sns.ca",
+        organisation=cds_org,
+    )
 
     owasp_zap_template = Template(
         name="OWASP Zap template",
@@ -101,10 +113,10 @@ if __name__ == "__main__":
     session.add(axe_core_scan)
 
     owasp_zap_report_f = open(
-        "../tests/storage/fixtures/owasp_zap_report.json",
+        "./tests/storage/fixtures/owasp_zap_report.json",
     )
     axe_core_report_f = open(
-        "../tests/storage/fixtures/axe_core_report.json",
+        "./tests/storage/fixtures/axe_core_report.json",
     )
 
     owasp_zap_data = json.load(owasp_zap_report_f)
@@ -145,3 +157,5 @@ if __name__ == "__main__":
 
         owasp_zap_data["id"] = str(security_report.id)
         storage.store_owasp_zap_record(session, owasp_zap_data)
+
+    print("Seed completed!")

--- a/api/front_end/templates/dashboard.html
+++ b/api/front_end/templates/dashboard.html
@@ -1,6 +1,17 @@
 {% extends "base.html" %}
 {% block body %}
-  <h1 class="text-center">{{ organisations_locale }}</h1>
+  <nav
+    class="block text-sm text-left text-green-800 h-12 flex items-center p-4 mb-5 border-2 border-gray-500"
+    role="alert"
+  >
+    <ol class="list-reset flex text-grey-dark">
+      <li><a href="/{{ lang }}" class="font-bold">{{home_locale}}</a></li>
+      <li><span class="mx-2">/</span></li>
+      <li>{{organisations_locale}}</li>
+    </ol>
+  </nav>
+  <h1 class="text-gray-700 font-semibold uppercase text-xl mb-7">{{ organisations_locale }}</h1>
+  <hr class="my-3"/>
   <div class="flex flex-col">
     <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
       <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">

--- a/api/front_end/templates/index.html
+++ b/api/front_end/templates/index.html
@@ -5,7 +5,7 @@
     role="alert"
   >
     <ol class="list-reset flex text-grey-dark">
-      <li><a href="/{{ lang }}" class="font-bold">{{dashboard_locale}}</a></li>
+      <li><a href="/{{ lang }}" class="font-bold">{{home_locale}}</a></li>
     </ol>
   </nav>
   
@@ -33,11 +33,11 @@
                     {% endif %}
                   </h3>
                   <div class="container flex flex-row gap-1">
-                    <div class="relative flex-1 flex flex-col gap-2 px-1">
+                    <div class="relative flex-1 flex flex-col gap-2">
                       <span class="font-semibold">{{ revisions_locale }}</span>
                       <div class="text-green-800 text-4xl font-bold">{{ scan.security_reports | length }}</div>
                     </div>
-                    <div class="relative flex-1 flex flex-col gap-2 px-1">
+                    <div class="relative flex-1 flex flex-col gap-2">
                       <span class="font-semibold">{{ violations_locale }}</span>
                       <div class="text-green-800 text-4xl font-bold">{{ scan.security_reports[0].security_violations | length }}</div>
                     </div>
@@ -65,11 +65,11 @@
                   {% endif %}
                 </div>
                   <div class="container flex flex-row gap-1">
-                    <div class="relative flex-1 flex flex-col gap-2 px-1">
+                    <div class="relative flex-1 flex flex-col gap-2">
                       <span class="font-semibold">{{ revisions_locale }}</span>
                       <div class="text-green-800 text-4xl font-bold">{{ scan.a11y_reports | length }}</div>
                     </div>
-                    <div class="relative flex-1 flex flex-col gap-2 px-1">
+                    <div class="relative flex-1 flex flex-col gap-2">
                       <span class="font-semibold">{{ violations_locale }}</span>
                       <div class="text-green-800 text-4xl font-bold">{{ scan.a11y_reports[0].a11y_violations | length }}</div>
                     </div>

--- a/api/front_end/templates/login.html
+++ b/api/front_end/templates/login.html
@@ -3,12 +3,18 @@
   
     <div class="container flex justify-center items-center">
         <div class="p-8 bg-white rounded-lg max-w-6xl pb-10">
-            <div class="flex justify-between items-center mt-3">
-                 <span class="p-2 text-gray-400 mb-1">{{ login_text_locale }}</span>
-            </div> 
+          <div class="flex justify-between items-center mt-3">
+            <span class="p-2 text-gray-400 mb-1">{{ login_text_locale }}</span>
+          </div> 
+          {% if heroku %}
+            <form action="/login/heroku">
+              <button class="h-12 mt-3 text-white w-full rounded bg-purple-800 hover:bg-purple-900">Heroku</button>
+            </form>
+          {% else %}
             <form action="/login/google">
-            <button class="h-12 mt-3 text-white w-full rounded bg-red-800 hover:bg-red-900">Google</button>
-          </form>
+              <button class="h-12 mt-3 text-white w-full rounded bg-red-800 hover:bg-red-900">Google</button>
+            </form>
+          {% endif %}
         </div>
     </div>
   {% block footer %}

--- a/api/front_end/templates/scan_results_a11y.html
+++ b/api/front_end/templates/scan_results_a11y.html
@@ -5,7 +5,7 @@
   role="alert"
 >
   <ol class="list-reset flex text-grey-dark">
-    <li><a href="/{{ lang }}" class="font-bold">{{dashboard_locale}}</a></li>
+    <li><a href="/{{ lang }}" class="font-bold">{{home_locale}}</a></li>
     <li><span class="mx-2">/</span></li>
     <li>{{ scan.template.name }}: {{ scan.scan_type.name }}</li>
   </ol>

--- a/api/front_end/templates/scan_results_security.html
+++ b/api/front_end/templates/scan_results_security.html
@@ -9,7 +9,7 @@
   role="alert"
 >
   <ol class="list-reset flex text-grey-dark">
-    <li><a href="/{{ lang }}" class="font-bold">{{dashboard_locale}}</a></li>
+    <li><a href="/{{ lang }}" class="font-bold">{{home_locale}}</a></li>
     <li><span class="mx-2">/</span></li>
     <li>{{ scan.template.name }}: {{ scan.scan_type.name }}</li>
   </ol>

--- a/api/front_end/templates/scan_results_security_details.html
+++ b/api/front_end/templates/scan_results_security_details.html
@@ -5,7 +5,7 @@
   role="alert"
 >
   <ol class="list-reset flex text-grey-dark">
-    <li><a href="/{{ lang }}" class="font-bold">{{dashboard_locale}}</a></li>
+    <li><a href="/{{ lang }}" class="font-bold">{{home_locale}}</a></li>
     <li><span class="mx-2">/</span></li>
     <li>{{ report.scan.template.name }}: {{ report.revision }} - {{ report.url }}</li>
   </ol>

--- a/api/front_end/templates/scan_results_security_summary.html
+++ b/api/front_end/templates/scan_results_security_summary.html
@@ -5,7 +5,7 @@
   role="alert"
 >
   <ol class="list-reset flex text-grey-dark">
-    <li><a href="/{{ lang }}" class="font-bold">{{dashboard_locale}}</a></li>
+    <li><a href="/{{ lang }}" class="font-bold">{{home_locale}}</a></li>
     <li><span class="mx-2">/</span></li>
     <li>{{ report.scan.template.name }}: {{ report.revision }} - {{ report.url }}</li>
   </ol>

--- a/api/front_end/templates/template.html
+++ b/api/front_end/templates/template.html
@@ -8,7 +8,7 @@
     role="alert"
   >
     <ol class="list-reset flex text-grey-dark">
-      <li><a href="/{{ lang }}" class="font-bold">{{dashboard_locale}}</a></li>
+      <li><a href="/{{ lang }}" class="font-bold">{{home_locale}}</a></li>
       <li><span class="mx-2">/</span></li>
       <li>{{templates_locale}}</li>
     </ol>
@@ -17,8 +17,9 @@
   <hr class="my-3"/>
   <div class="flex flex-col">
     <form id="newTemplateForm" class="w-full max-w-sm" action="/scans/template" method="POST">
-      <div class="flex items-center border-b  py-2 ">
-        <stong>{{ templates_locale }}</stong>: <input class="appearance-none  w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none" name="name" type="text" placeholder="www.example.com" aria-label="{{ template_name_locale }}">
+      <div class="flex items-center border-b py-2 ">
+        {{ templates_locale }}:
+        <input class="appearance-none  w-full text-gray-700 mx-3 py-1 px-2 leading-tight focus:outline-none" name="name" type="text" placeholder="www.example.com" aria-label="{{ template_name_locale }}">
         <button class="flex-shrink-0 bg-green-500 hover:bg-green-700 border-green-500 hover:border-green-700 text-sm border-4 text-black py-1 px-2 rounded" type="submit">
           {{ new_locale }}
         </button>

--- a/api/front_end/templates/template_scan.html
+++ b/api/front_end/templates/template_scan.html
@@ -8,7 +8,7 @@
   role="alert"
 >
   <ol class="list-reset flex text-grey-dark">
-    <li><a href="/{{ lang }}" class="font-bold">{{dashboard_locale}}</a></li>
+    <li><a href="/{{ lang }}" class="font-bold">{{home_locale}}</a></li>
     <li><span class="mx-2">/</span></li>
     <li><a href="/{{ lang }}/template" class="font-bold">{{templates_locale}}</a></li>
     <li><span class="mx-2">/</span></li>

--- a/api/front_end/templates/template_scan_list.html
+++ b/api/front_end/templates/template_scan_list.html
@@ -9,7 +9,7 @@
   role="alert"
 >
   <ol class="list-reset flex text-grey-dark">
-    <li><a href="/{{ lang }}" class="font-bold">{{dashboard_locale}}</a></li>
+    <li><a href="/{{ lang }}" class="font-bold">{{home_locale}}</a></li>
     <li><span class="mx-2">/</span></li>
     <li><a href="/{{ lang }}/template" class="font-bold">{{templates_locale}}</a></li>
     <li><span class="mx-2">/</span></li>

--- a/api/front_end/templates/user.html
+++ b/api/front_end/templates/user.html
@@ -8,7 +8,7 @@
     role="alert"
   >
     <ol class="list-reset flex text-grey-dark">
-      <li><a href="/{{ lang }}" class="font-bold">{{dashboard_locale}}</a></li>
+      <li><a href="/{{ lang }}" class="font-bold">{{home_locale}}</a></li>
       <li><span class="mx-2">/</span></li>
       <li>{{my_account_locale}}</li>
     </ol>

--- a/api/front_end/view.py
+++ b/api/front_end/view.py
@@ -327,7 +327,10 @@ async def login(request: Request, locale: str):
         if locale not in languages:
             locale = default_fallback
 
-        result = {"request": request}
+        result = {
+            "request": request,
+            "heroku": os.environ.get("HEROKU_PR_NUMBER", False),
+        }
         result.update(languages[locale])
         return templates.TemplateResponse("login.html", result)
     except Exception as e:

--- a/api/i18n/en.json
+++ b/api/i18n/en.json
@@ -16,6 +16,7 @@
   "existing_scans_locale": "Existing scans",
   "goc_locale": "Government of Canada",
   "goc_banner_locale": "https://ssl-templates.services.gc.ca/app/cls/wet/gcintranet/v4_0_20/assets/sig-blk-en.svg",
+  "home_locale": "Home",
   "key_locale": "Key",
   "lang": "en",
   "list_of_products_locale": "List of all products",

--- a/api/i18n/fr.json
+++ b/api/i18n/fr.json
@@ -16,6 +16,7 @@
   "existing_scans": "Analyses existantes",
   "goc_locale": "Gouvernement du Canada",
   "goc_banner_locale": "https://ssl-templates.services.gc.ca/app/cls/wet/gcintranet/v4_0_20/assets/sig-blk-fr.svg",
+  "home_locale": "Accueil",
   "key_locale": "Clé",
   "lang": "fr",
   "list_of_products_locale": "Liste de tous les produits",

--- a/api/tests/api_gateway/test_auth.py
+++ b/api/tests/api_gateway/test_auth.py
@@ -1,0 +1,33 @@
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+from api_gateway import api
+from models.User import User
+
+import os
+
+client = TestClient(api.app)
+
+
+def test_heroku_login_401_if_HEROKU_PR_NUMBER_ENV_missing():
+    response = client.get("/login/heroku")
+    assert response.status_code == 401
+
+
+@patch.dict(os.environ, {"HEROKU_PR_NUMBER": "foo"}, clear=True)
+def test_heroku_login_401_if_user_missing():
+    response = client.get("/login/heroku")
+    assert response.status_code == 401
+
+
+@patch.dict(os.environ, {"HEROKU_PR_NUMBER": "foo"}, clear=True)
+def test_heroku_login_redirect_if_seed_user_exists(session, home_organisation_fixture):
+    user = User(
+        name="Seed User",
+        email_address="scan-websites+seed@cds-sns.ca",
+        organisation=home_organisation_fixture,
+    )
+    session.add(user)
+    session.commit()
+    response = client.get("/login/heroku", allow_redirects=False)
+    assert response.status_code == 307

--- a/app.json
+++ b/app.json
@@ -1,0 +1,26 @@
+{
+    "name": "Scan websites",
+    "success_url": "/en",
+    "scripts": {
+        "postdeploy": "cd api && make heroku seed"
+    },
+    "env": {
+        "FASTAPI_SECRET_KEY": {
+            "description": "A secret key for verifying the integrity of signed cookies.",
+            "generator": "secret"
+        }
+    },
+    "addons": [
+        {
+            "plan": "heroku-postgresql",
+            "options": {
+                "version": "9.5"
+            }
+        }
+    ],
+    "buildpacks": [
+        {
+            "url": "heroku/python"
+        }
+    ]
+}


### PR DESCRIPTION
Closes #198 by enabling Heroku PR review apps. Because Google Auth does not support dynamic URLs we need to add a bypass to the login. If the app detects the `HEROKU_PR_NUMBER` env variable, it will allow a user to log in with a seeded user. In production, this ENV should be missing and there should not be a seeded user with this bespoke email. 