### PR TITLE
fix: state function match scan type

### DIFF
--- a/terragrunt/env/orchestrator/state-machines/dynamic-security-scans.json
+++ b/terragrunt/env/orchestrator/state-machines/dynamic-security-scans.json
@@ -13,13 +13,13 @@
           "Next": "Done"
         },
         {
-          "Variable": "$.payload[0].name",
+          "Variable": "$.payload[0].type",
           "StringMatches": "nuclei",
           "Next": "nuclei"
         },
         {
-          "Variable": "$.payload[0].name",
-          "StringMatches": "owasp-zap",
+          "Variable": "$.payload[0].type",
+          "StringMatches": "OWASP Zap",
           "Next": "owasp-zap"
         }
       ],


### PR DESCRIPTION
State machine definition isn't referencing the correct items in the payload array.

No change to plan since i tested/debugged using the console.