### PR TITLE
fix: nuclei type name has wrong case

### DIFF
--- a/api/pub_sub/pub_sub.py
+++ b/api/pub_sub/pub_sub.py
@@ -24,7 +24,7 @@ from models.User import User  # noqa: F401
 
 class AvailableScans(Enum):
     OWASP_ZAP = "OWASP Zap"
-    NUCLEI = "nuclei"
+    NUCLEI = "Nuclei"
     AXE_CORE = "axe-core"
 
 

--- a/terragrunt/env/orchestrator/state-machines/dynamic-security-scans.json
+++ b/terragrunt/env/orchestrator/state-machines/dynamic-security-scans.json
@@ -14,7 +14,7 @@
         },
         {
           "Variable": "$.payload[0].type",
-          "StringMatches": "nuclei",
+          "StringMatches": "Nuclei",
           "Next": "nuclei"
         },
         {


### PR DESCRIPTION
Nuclei enum doesn't match what's in database.