### PR TITLE
feat: add aws otel lambda as docker image 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,6 @@ dist
 
 # Ignore local stack data file
 .devcontainer/data
+
+# VSCode settings
+.vscode

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,12 +3,12 @@ FROM public.ecr.aws/cds-snc/opentelemetry-python-lambda:1.7.1 as otel
 # Define function directory
 ARG FUNCTION_DIR="/function"
 
+COPY --from=otel /opt /opt
+
 FROM python:3.9-slim-buster
 
 # Define function directory
 ARG FUNCTION_DIR="/function"
-
-COPY --from=otel /opt /opt
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -34,9 +34,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get autoremove -y \
     && apt-get clean -y
 
-# Include global arg in this stage of the build
-ARG FUNCTION_DIR
-
 WORKDIR ${FUNCTION_DIR}
 
 RUN mkdir -p /pymodules

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,11 +1,8 @@
 FROM public.ecr.aws/cds-snc/opentelemetry-python-lambda:1.7.1 as otel
 
-# Define function directory
-ARG FUNCTION_DIR="/function"
+FROM python:3.9-slim-buster
 
 COPY --from=otel /opt /opt
-
-FROM python:3.9-slim-buster
 
 # Define function directory
 ARG FUNCTION_DIR="/function"

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,11 @@
+FROM public.ecr.aws/cds-snc/opentelemetry-python-lambda:1.7.1 as otel
+
 # Define function directory
 ARG FUNCTION_DIR="/function"
 
 FROM python:3.9-slim-buster
+
+COPY --from=otel /opt /opt
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,6 +5,9 @@ ARG FUNCTION_DIR="/function"
 
 FROM python:3.9-slim-buster
 
+# Define function directory
+ARG FUNCTION_DIR="/function"
+
 COPY --from=otel /opt /opt
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Also included: 

update gitignore  

add otel tracing variable to lambda tf

# Summary | Résumé

Added code from AWS Otel lambda layer to docker image in ecr. We then pull that image in to run it directly in the app since layers are not available for lambdas using containers. (Yet, presumably they will add this function à la Honeycomb et al.)


