### PR TITLE
fix: add AWS Lambda exec wrapper env variable

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -11,6 +11,7 @@ resource "aws_lambda_function" "api" {
 
   environment {
     variables = {
+      AWS_LAMBDA_EXEC_WRAPPER      = "/opt/otel-instrument"
       AXE_CORE_URLS_TOPIC          = aws_sns_topic.axe-core-urls.arn
       AXE_CORE_REPORT_DATA_BUCKET  = module.axe-core-report-data.s3_bucket_id
       AXE_CORE_SCREENSHOT_BUCKET   = module.axe-core-screenshots.s3_bucket_id


### PR DESCRIPTION
# Summary
Re-enables the AWS Lambda exec wrapper environment variable to use the `otel-instrument` binary to execute requests. 