### PR TITLE
fix: a11y scans thread and dispatch issue resolved

### DIFF
--- a/api/api_gateway/routers/scans.py
+++ b/api/api_gateway/routers/scans.py
@@ -128,7 +128,7 @@ def build_scan_payload(template, template_scan, scan, git_sha=None):
 
 @router.get("/start")
 @router.get("/start/revision/{git_sha}")
-async def start_scan(
+def start_scan(
     request: Request,
     background_tasks: BackgroundTasks,
     git_sha: Optional[str] = None,
@@ -167,8 +167,7 @@ async def start_scan(
         item = build_scan_payload(template, template_scan, scan, git_sha)
         try:
             if item["crawl"] == "true":
-                # background_tasks.add_task(crawl, item)
-                await crawl(item)
+                background_tasks.add_task(crawl, item)
                 success_list.append(template_scan.scan_type.name)
             else:
                 payload_list.append(item)

--- a/api/api_gateway/routers/scans.py
+++ b/api/api_gateway/routers/scans.py
@@ -128,7 +128,7 @@ def build_scan_payload(template, template_scan, scan, git_sha=None):
 
 @router.get("/start")
 @router.get("/start/revision/{git_sha}")
-def start_scan(
+async def start_scan(
     request: Request,
     background_tasks: BackgroundTasks,
     git_sha: Optional[str] = None,

--- a/api/api_gateway/routers/scans.py
+++ b/api/api_gateway/routers/scans.py
@@ -128,7 +128,7 @@ def build_scan_payload(template, template_scan, scan, git_sha=None):
 
 @router.get("/start")
 @router.get("/start/revision/{git_sha}")
-def start_scan(
+async def start_scan(
     request: Request,
     background_tasks: BackgroundTasks,
     git_sha: Optional[str] = None,
@@ -167,7 +167,8 @@ def start_scan(
         item = build_scan_payload(template, template_scan, scan, git_sha)
         try:
             if item["crawl"] == "true":
-                background_tasks.add_task(crawl, item)
+                # background_tasks.add_task(crawl, item)
+                await crawl(item)
                 success_list.append(template_scan.scan_type.name)
             else:
                 payload_list.append(item)

--- a/api/front_end/templates/index.html
+++ b/api/front_end/templates/index.html
@@ -82,16 +82,18 @@
                         <path d="M12 7C11.7239 7 11.5 6.77614 11.5 6.5C11.5 6.22386 11.7239 6 12 6C12.2761 6 12.5 6.22386 12.5 6.5C12.5 6.77614 12.2761 7 12 7Z" fill="black" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                       </svg>
                     </div>
-                    {% if scan.a11y_reports | length > 1 and 'total' in scan.a11y_reports[0].summary.violations and scan.a11y_reports[0].summary.violations['total'] > 0 %}
-                    {% set delta = (scan.a11y_reports[0].summary.violations['total'] - scan.a11y_reports[1].summary.violations['total'])|int %}
-                      {% if delta > 0  %}
-                      <div class="text-red-500 mr-4 mt-3 font-semibold text-center">
-                        +{{ delta }}
-                      </div>
-                      {% elif delta < 0 %}
-                      <div class="text-green-500 mr-4 mt-3 font-semibold text-center">
-                        {{ delta }}
-                      </div>
+                    {% if scan.a11y_reports | length > 1 and 'violations' in scan.a11y_reports[0].summary and 'violations' in scan.a11y_reports[1].summary %}
+                      {% if 'total' in scan.a11y_reports[0].summary.violations and scan.a11y_reports[0].summary.violations['total'] > 0 %}
+                      {% set delta = (scan.a11y_reports[0].summary.violations['total'] - scan.a11y_reports[1].summary.violations['total'])|int %}
+                        {% if delta > 0  %}
+                        <div class="text-red-500 mr-4 mt-3 font-semibold text-center">
+                          +{{ delta }}
+                        </div>
+                        {% elif delta < 0 %}
+                        <div class="text-green-500 mr-4 mt-3 font-semibold text-center">
+                          {{ delta }}
+                        </div>
+                        {% endif %}
                       {% endif %}
                     {% endif %}
                   </div>

--- a/api/front_end/templates/scan_results_a11y.html
+++ b/api/front_end/templates/scan_results_a11y.html
@@ -46,43 +46,45 @@
               </thead>
               <tbody class="bg-white divide-y divide-gray-200">
                 {% for a11y_report in scan.a11y_reports %}
-                  <tr>
-                    <td class="px-6 py-4 whitespace-nowrap truncate">
-                      <div class="text-sm font-medium text-gray-900">
-                        {{ a11y_report.url }}
-                      </div>
+                  {% if 'violations' in a11y_report.summary %}
+                    <tr>
+                      <td class="px-6 py-4 whitespace-nowrap truncate">
+                        <div class="text-sm font-medium text-gray-900">
+                          {{ a11y_report.url }}
+                        </div>
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap">
+                        <div class="text-sm font-medium">
+                          {{ a11y_report.created_at.strftime('%d-%m-%Y %H:%M:%S') }}
+                        </div>
+                      </td>
+                      <td class="px-6 py-4 whitespace-nowrap">
+                        <div class="text-sm font-medium text-gray-900">
+                          <p class="flex flex-wrap gap-2">
+                            <span class="{{ 'bg-red-300' if a11y_report.summary.violations.critical | default(0) > 0 else 'bg-gray-100'}} inline-block p-1 px-2">{{a11y_report.summary.violations['critical'] or 0 }}&nbsp;{{ critical_locale }}</span>
+                            <span class="{{ 'bg-orange-300' if a11y_report.summary.violations.serious | default(0) > 0 else 'bg-gray-100'}} inline-block p-1 px-2">{{a11y_report.summary.violations['serious'] or 0 }}&nbsp;{{ serious_locale }}</span>
+                            <span class="{{ 'bg-yellow-300' if a11y_report.summary.violations.moderate | default(0) > 0 else 'bg-gray-100'}} inline-block p-1 px-2">{{a11y_report.summary.violations['moderate'] or 0 }}&nbsp;{{ moderate_locale }}</span>
+                            <span class="{{ 'bg-lime-300' if a11y_report.summary.violations.minor | default(0) > 0 else 'bg-gray-100'}} inline-block p-1 px-2">{{a11y_report.summary.violations['minor'] or 0 }}&nbsp;{{ minor_locale }}</span>
+                          </p>
+                        </div>
+                      </td>
+                      <td class="text-center">
+                        <a href="/{{ lang }}/results/{{ scan.template.id }}/a11y/{{scan.id}}/{{ a11y_report.id }}">
+                          <span class="material-icons">description</span>
+                        </a>
+                      </td>
+                      <td class="text-center">
+                        <a href="/{{ lang }}/results/{{ scan.template.id }}/a11y/{{scan.id}}/{{ a11y_report.id }}/screenshot">
+                          <span class="material-icons">image</span>
+                        </a>
+                      </td>
+                      <td class="text-center">
+                        <a href="{{a11y_report.url}}" target="_blank">
+                          <span class="material-icons">ios_share</span>
+                        </a>
+                      </tr>
                     </td>
-                    <td class="px-6 py-4 whitespace-nowrap">
-                      <div class="text-sm font-medium">
-                        {{ a11y_report.created_at.strftime('%d-%m-%Y %H:%M:%S') }}
-                      </div>
-                    </td>
-                    <td class="px-6 py-4 whitespace-nowrap">
-                      <div class="text-sm font-medium text-gray-900">
-                        <p class="flex flex-wrap gap-2">
-                          <span class="{{ 'bg-red-300' if a11y_report.summary.violations.critical | default(0) > 0 else 'bg-gray-100'}} inline-block p-1 px-2">{{a11y_report.summary.violations['critical'] or 0 }}&nbsp;{{ critical_locale }}</span>
-                          <span class="{{ 'bg-orange-300' if a11y_report.summary.violations.serious | default(0) > 0 else 'bg-gray-100'}} inline-block p-1 px-2">{{a11y_report.summary.violations['serious'] or 0 }}&nbsp;{{ serious_locale }}</span>
-                          <span class="{{ 'bg-yellow-300' if a11y_report.summary.violations.moderate | default(0) > 0 else 'bg-gray-100'}} inline-block p-1 px-2">{{a11y_report.summary.violations['moderate'] or 0 }}&nbsp;{{ moderate_locale }}</span>
-                          <span class="{{ 'bg-lime-300' if a11y_report.summary.violations.minor | default(0) > 0 else 'bg-gray-100'}} inline-block p-1 px-2">{{a11y_report.summary.violations['minor'] or 0 }}&nbsp;{{ minor_locale }}</span>
-                        </p>
-                      </div>
-                    </td>
-                    <td class="text-center">
-                      <a href="/{{ lang }}/results/{{ scan.template.id }}/a11y/{{scan.id}}/{{ a11y_report.id }}">
-                        <span class="material-icons">description</span>
-                      </a>
-                    </td>
-                    <td class="text-center">
-                      <a href="/{{ lang }}/results/{{ scan.template.id }}/a11y/{{scan.id}}/{{ a11y_report.id }}/screenshot">
-                        <span class="material-icons">image</span>
-                      </a>
-                    </td>
-                    <td class="text-center">
-                      <a href="{{a11y_report.url}}" target="_blank">
-                        <span class="material-icons">ios_share</span>
-                      </a>
-                    </tr>
-                  </td>
+                  {% endif %}
                 {% endfor %}
               </tbody>
             </table>

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -16,3 +16,4 @@ python-multipart==0.0.5
 SQLAlchemy==1.4.22
 scrapy==2.5.0
 scrapy-playwright==0.0.4
+uvloop==0.16.0

--- a/api/requirements_dev.txt
+++ b/api/requirements_dev.txt
@@ -3,5 +3,6 @@ coverage==5.5
 factory-boy==3.2.0
 flake8==3.9.2
 pytest==6.2.4
+pytest-asyncio==0.16.0
 requests==2.25.1
 uvicorn==0.14.0

--- a/api/tests/api_gateway/test_scans.py
+++ b/api/tests/api_gateway/test_scans.py
@@ -512,10 +512,10 @@ def test_start_scan_valid_api_keys_with_gitsha(
     )
 
 
-@patch("fastapi.BackgroundTasks.add_task")
+@patch("api_gateway.routers.scans.crawl")
 @patch.dict(os.environ, {"OWASP_ZAP_URLS_TOPIC": "topic"}, clear=True)
 def test_start_scan_valid_api_keys_with_crawling(
-    mock_add_task,
+    mock_crawl,
     session,
     authorized_request,
 ):
@@ -546,8 +546,7 @@ def test_start_scan_valid_api_keys_with_crawling(
 
     assert response.status_code == 200
 
-    mock_add_task.assert_called_once_with(
-        ANY,
+    mock_crawl.assert_called_once_with(
         {
             "type": AvailableScans.OWASP_ZAP.value,
             "product": template.name,


### PR DESCRIPTION
Closes #255

- Fixes dispatch that has been broken since the pub_sub functionality was refactored to accept a list of payloads to dispatch.
- Crawl moved into a async function
- Error handling added to a11y views