### PR TITLE
feat: retrieve lambda layer on build

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -48,6 +48,16 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
+      - name: Retrieve AWS Distro for OpenTelemetry Lambda layer
+        if: matrix.image == 'api'
+        working-directory: ./${{ matrix.image }}
+        run: |
+          aws lambda get-layer-version-by-arn \
+          --region ca-central-1 \
+          --arn arn:aws:lambda:ca-central-1:901920570463:layer:aws-otel-python38-ver-1-7-1:1 \
+          | jq -r '.Content.Location' \
+          | xargs curl -o otel-layer.zip
+          
       - name: Login to ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1

--- a/.github/workflows/ci_build_continers.yml
+++ b/.github/workflows/ci_build_continers.yml
@@ -48,6 +48,16 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
+      - name: Retrieve AWS Distro for OpenTelemetry Lambda layer
+        if: matrix.image == 'api'
+        working-directory: ./${{ matrix.image }}
+        run: |
+          aws lambda get-layer-version-by-arn \
+          --region ca-central-1 \
+          --arn arn:aws:lambda:ca-central-1:901920570463:layer:aws-otel-python38-ver-1-7-1:1 \
+          | jq -r '.Content.Location' \
+          | xargs curl -o otel-layer.zip
+
       - name: Login to ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+otel-layer.zip
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.9-slim-buster
 
-COPY --from=public.ecr.aws/cds-snc/opentelemetry-python-lambda:1.7.1 /opt /opt
 # Define function directory
 ARG FUNCTION_DIR="/function"
 
@@ -23,6 +22,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     postgresql-client \
     openssh-client \
     python3-pip \
+    unzip \
     vim \
     wget \
     xz-utils \
@@ -30,6 +30,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     entr \
     && apt-get autoremove -y \
     && apt-get clean -y
+
+COPY otel-layer.zip /tmp
+RUN unzip /tmp/otel-layer.zip -d /opt && rm /tmp/otel-layer.zip
 
 WORKDIR ${FUNCTION_DIR}
 

--- a/bin/retrieve_otel_layer.sh
+++ b/bin/retrieve_otel_layer.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+aws lambda get-layer-version-by-arn \
+--region ca-central-1 \
+--arn arn:aws:lambda:ca-central-1:901920570463:layer:aws-otel-python38-ver-1-7-1:1 \
+| jq -r '.Content.Location' \
+| xargs curl -o ../api/otel-layer.zip


### PR DESCRIPTION
Instead of using a prebuilt docker image, download the contents of the lambda layer instead.