### PR TITLE
fix: working opentelemetry

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,10 +1,9 @@
-FROM python:3.9-slim-buster
+FROM amazon/aws-lambda-python:3.8
 
 # Define function directory
 ARG FUNCTION_DIR="/function"
 
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends \
+RUN yum -y install \
     ca-certificates \
     curl \
     git \
@@ -28,11 +27,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     xz-utils \
     zsh \
     entr \
-    && apt-get autoremove -y \
-    && apt-get clean -y
-
-COPY otel-layer.zip /tmp
-RUN unzip /tmp/otel-layer.zip -d /opt && rm /tmp/otel-layer.zip
+    && yum -y autoremove \
+    && yum clean all
 
 WORKDIR ${FUNCTION_DIR}
 
@@ -42,33 +38,21 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/pymodules/playwright
 
 COPY ./requirements_playwright.txt ${FUNCTION_DIR}
 
-RUN python3.9 -m pip install -r ${FUNCTION_DIR}/requirements_playwright.txt
+RUN python -m pip install -r ${FUNCTION_DIR}/requirements_playwright.txt
 
 COPY ./requirements.txt ${FUNCTION_DIR}
 
-RUN python3.9 -m pip install -r ${FUNCTION_DIR}/requirements.txt --target /pymodules
+RUN python -m pip install -r ${FUNCTION_DIR}/requirements.txt --target /pymodules
 
 RUN playwright install chromium
 
-# Install the runtime interface client
-RUN pip install --target /pymodules \
-    awslambdaric
-
 # Copy function code
 COPY . ${FUNCTION_DIR}
+
+RUN unzip otel-layer.zip -d /opt && rm otel-layer.zip
 
 # Set build variables
 ARG git_sha
 ENV GIT_SHA=$git_sha
 
-# Install lambda runtime interactive environment
-ARG RIE_VERSION=1.1
-ARG AWS_RIE_SRC=https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/download
-RUN wget -O aws-lambda-rie ${AWS_RIE_SRC}/${RIE_VERSION}/aws-lambda-rie \
-    && mv aws-lambda-rie /usr/bin/aws-lambda-rie
-
-COPY bin/entry.sh /
-RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh
-
-ENTRYPOINT [ "/entry.sh" ]
 CMD [ "main.handler" ]

--- a/api/Dockerfile.heroku
+++ b/api/Dockerfile.heroku
@@ -1,7 +1,7 @@
 # Define function directory
 ARG FUNCTION_DIR="/function"
 
-FROM python:3.9-slim-buster
+FROM python:3.8-slim-buster
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
@@ -41,15 +41,15 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/pymodules/playwright
 
 COPY ./requirements_playwright.txt ${FUNCTION_DIR}
 
-RUN python3.9 -m pip install -r ${FUNCTION_DIR}/requirements_playwright.txt
+RUN python -m pip install -r ${FUNCTION_DIR}/requirements_playwright.txt
 
 COPY ./requirements.txt ${FUNCTION_DIR}
 
-RUN python3.9 -m pip install -r ${FUNCTION_DIR}/requirements.txt --target /pymodules
+RUN python -m pip install -r ${FUNCTION_DIR}/requirements.txt --target /pymodules
 
 COPY ./requirements_dev.txt ${FUNCTION_DIR}
 
-RUN python3.9 -m pip install -r ${FUNCTION_DIR}/requirements_dev.txt --target /pymodules
+RUN python -m pip install -r ${FUNCTION_DIR}/requirements_dev.txt --target /pymodules
 
 # DO NOT INSTALL CHROMIUM
 # RUN playwright install chromium

--- a/api/main.py
+++ b/api/main.py
@@ -23,7 +23,6 @@ from models.TemplateScanTrigger import TemplateScanTrigger  # noqa: F401
 from models.User import User  # noqa: F401
 
 app = api.app
-FastAPIInstrumentor.instrument_app(app)
 metrics = Metrics(namespace="ScanWebsites", service="api")
 
 
@@ -39,6 +38,7 @@ def handler(event, context):
     # TODO: handle different events other than https
     if "httpMethod" in event:
         # Assume it is an API Gateway event
+        FastAPIInstrumentor.instrument_app(app)
         asgi_handler = Mangum(app)
         response = asgi_handler(event, context)
         return response

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -12,9 +12,7 @@ itsdangerous==2.0.1
 logzero==1.7.0
 mangum==0.12.1
 opentelemetry-api==1.7.1
-opentelemetry-exporter-otlp==1.7.1
 opentelemetry-instrumentation-fastapi==0.26b1
-opentelemetry-propagator-aws-xray==1.0.1
 opentelemetry-sdk-extension-aws==2.0.1
 psycopg2-binary==2.9.1
 python-multipart==0.0.5


### PR DESCRIPTION
AWS lambda opentelemetry auto instrumentation assumes that you're setup exactly the same as lambda runtime environments (either using lambda layers or container images).

Migrating to using the amazon/lambda-python will make it less work to maintain observability in the future or to leverage new tools that work in lambda.