### PR TITLE
feat: debian based opentelemetry autoinstrumentation

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,9 +1,10 @@
-FROM amazon/aws-lambda-python:3.8
+FROM python:3.8-slim-buster
 
 # Define function directory
 ARG FUNCTION_DIR="/function"
 
-RUN yum -y install \
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
     ca-certificates \
     curl \
     git \
@@ -27,24 +28,30 @@ RUN yum -y install \
     xz-utils \
     zsh \
     entr \
-    && yum -y autoremove \
-    && yum clean all
+    && apt-get autoremove -y \
+    && apt-get clean -y
 
 WORKDIR ${FUNCTION_DIR}
 
 RUN mkdir -p /pymodules
+
 ENV PYTHONPATH=/pymodules
+ENV LAMBDA_RUNTIME_DIR=/pymodules
 ENV PLAYWRIGHT_BROWSERS_PATH=/pymodules/playwright
 
 COPY ./requirements_playwright.txt ${FUNCTION_DIR}
 
-RUN python -m pip install -r ${FUNCTION_DIR}/requirements_playwright.txt
+RUN python3.8 -m pip install -r ${FUNCTION_DIR}/requirements_playwright.txt
 
 COPY ./requirements.txt ${FUNCTION_DIR}
 
-RUN python -m pip install -r ${FUNCTION_DIR}/requirements.txt --target /pymodules
+RUN python3.8 -m pip install -r ${FUNCTION_DIR}/requirements.txt --target /pymodules
 
 RUN playwright install chromium
+
+# Install the runtime interface client
+RUN pip install --target /pymodules \
+    awslambdaric
 
 # Copy function code
 COPY . ${FUNCTION_DIR}
@@ -55,4 +62,14 @@ RUN unzip otel-layer.zip -d /opt && rm otel-layer.zip
 ARG git_sha
 ENV GIT_SHA=$git_sha
 
+# Install lambda runtime interactive environment
+ARG RIE_VERSION=1.1
+ARG AWS_RIE_SRC=https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/download
+RUN wget -O aws-lambda-rie ${AWS_RIE_SRC}/${RIE_VERSION}/aws-lambda-rie \
+    && mv aws-lambda-rie /usr/bin/aws-lambda-rie
+
+COPY bin/entry.sh /
+RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh
+
+ENTRYPOINT [ "/entry.sh" ]
 CMD [ "main.handler" ]

--- a/api/bin/entry.sh
+++ b/api/bin/entry.sh
@@ -1,7 +1,12 @@
-#!/bin/sh
+#!/bin/bash
 if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
     echo "Running aws-lambda-rie"
     exec find . -name "*.py" | entr -r /usr/bin/aws-lambda-rie /usr/local/bin/python -m awslambdaric "$1"
 else
-    exec /usr/local/bin/python -m awslambdaric "$1"
+    if [ -z "$AWS_LAMBDA_EXEC_WRAPPER" ]; then
+        exec /usr/local/bin/python -m awslambdaric "$1"
+    else
+        # If Opentelemetry is enabled use the defined otel wrapper
+        exec -- "$AWS_LAMBDA_EXEC_WRAPPER" /usr/local/bin/python -m awslambdaric "$1"
+    fi
 fi


### PR DESCRIPTION
The missing link to the autoinstrumentation of our original docker image was the call to the python wrapper defined using the `AWS_LAMBDA_EXEC_WRAPPER` environment variable. This bootstraps the lambda handler invocation so that opentelemetry can create begin and end spans when the lambda starts and to detect all loaded python libraries that support auto instrumentation.

![image](https://user-images.githubusercontent.com/85885638/147099378-021d97ba-ec59-4aaf-a6c6-53903d519491.png)
