### PR TITLE
fix: background no longer blocked by middleware

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -96,3 +96,4 @@ output=json\n\
 
 RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g typescript" 2>&1
 ENV DEV_ENVIRONMENT=true
+ENV PATH=/home/vscode/.local/bin/:${PATH}

--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -2,13 +2,12 @@ from os import environ
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.authentication import AuthenticationMiddleware
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 
 from front_end import view, scan_view
 from .routers import auth, dev, ops, organisations, scans
-from .custom_middleware import add_security_headers
+from .middleware.security_headers import SecurityHeadersMiddleware
 
 app = FastAPI()
 
@@ -16,14 +15,9 @@ FASTAPI_SECRET_KEY = environ.get("FASTAPI_SECRET_KEY") or None
 if FASTAPI_SECRET_KEY is None:
     raise HTTPException(status_code=500, detail="Missing FASTAPI_SECRET_KEY")
 
-# https://github.com/tiangolo/fastapi/issues/1472; can't include custom middlware when running tests
-if environ.get("CI") is None:
-    app.add_middleware(BaseHTTPMiddleware, dispatch=add_security_headers)
-
-
+app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(AuthenticationMiddleware, backend=auth.SessionAuthBackend())
 app.add_middleware(SessionMiddleware, secret_key=FASTAPI_SECRET_KEY)
-
 
 app.include_router(auth.router)
 app.include_router(ops.router, prefix="/ops", tags=["ops"])

--- a/api/api_gateway/custom_middleware.py
+++ b/api/api_gateway/custom_middleware.py
@@ -1,9 +1,0 @@
-from fastapi import Request
-
-
-async def add_security_headers(request: Request, call_next):
-    response = await call_next(request)
-    response.headers[
-        "Strict-Transport-Security"
-    ] = "max-age=63072000; includeSubDomains; preload"
-    return response

--- a/api/api_gateway/middleware/security_headers.py
+++ b/api/api_gateway/middleware/security_headers.py
@@ -1,0 +1,24 @@
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+from starlette.datastructures import MutableHeaders
+
+# Custom class required to add headers in-order to not block background tasks
+# https://github.com/encode/starlette/issues/919
+
+
+class SecurityHeadersMiddleware:
+    def __init__(
+        self,
+        app: ASGIApp,
+    ) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                headers[
+                    "Strict-Transport-Security"
+                ] = "max-age=63072000; includeSubDomains; preload"
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)

--- a/api/crawler/crawler.py
+++ b/api/crawler/crawler.py
@@ -86,7 +86,7 @@ def runner(item):
     runner.start()
 
 
-async def crawl(item):
+def crawl(item):
     if not item["scan_id"] or not item["url"]:
         log.error(f"scan_id({item['scan_id']}) or url({item['url']}) missing")
         return

--- a/api/front_end/view.py
+++ b/api/front_end/view.py
@@ -102,7 +102,6 @@ def get_risk_colour(riskcode):
 def extract_risk_text(summary):
     reduced_summary = {}
     for key in summary:
-        print(key)
         if " (" in key:
             risk = str(key.split(" (")[0]).lower()
             reduced_summary[risk] = summary[key]

--- a/api/requirements_dev.txt
+++ b/api/requirements_dev.txt
@@ -3,6 +3,5 @@ coverage==5.5
 factory-boy==3.2.0
 flake8==3.9.2
 pytest==6.2.4
-pytest-asyncio==0.16.0
 requests==2.25.1
 uvicorn==0.14.0

--- a/api/tests/api_gateway/test_api.py
+++ b/api/tests/api_gateway/test_api.py
@@ -41,8 +41,8 @@ def test_healthcheck_failure(mock_log, mock_get_db_version):
     assert response.json() == expected_val
 
 
-def test_hsts_in_response(hsts_middleware_client):
-    response = hsts_middleware_client.get("/ops/version")
+def test_hsts_in_response():
+    response = client.get("/ops/version")
     assert response.status_code == 200
     assert (
         response.headers["Strict-Transport-Security"]

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -7,7 +7,6 @@ from alembic import command
 
 from api_gateway import api
 
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from factories import (
@@ -23,11 +22,6 @@ from factories import (
     TemplateScanFactory,
     UserFactory,
 )
-
-from api_gateway.custom_middleware import add_security_headers
-from api_gateway.routers import ops
-
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -95,13 +89,3 @@ def authorized_request(session, client):
     session.commit()
     client.post(f"/login/ci/{user.email_address}")
     yield client, user, organisation
-
-
-# https://github.com/tiangolo/fastapi/issues/1472; has to be tested seperate from Jinja2 routes
-@pytest.fixture
-def hsts_middleware_client():
-    app = FastAPI()
-    app.add_middleware(BaseHTTPMiddleware, dispatch=add_security_headers)
-    app.include_router(ops.router, prefix="/ops", tags=["ops"])
-    client = TestClient(app)
-    yield client

--- a/api/tests/crawler/test_crawler.py
+++ b/api/tests/crawler/test_crawler.py
@@ -1,5 +1,4 @@
 from crawler import crawler
-import pytest
 from unittest.mock import ANY, MagicMock, patch
 
 
@@ -7,32 +6,29 @@ def mock_item():
     return {"scan_id": "scan_id", "url": "url"}
 
 
-@pytest.mark.asyncio
 @patch("crawler.crawler.log")
-async def test_crawl_id_missing(mock_logger):
+def test_crawl_id_missing(mock_logger):
     item = mock_item()
     item["scan_id"] = None
-    await crawler.crawl(item)
+    crawler.crawl(item)
     mock_logger.error.assert_called_once_with("scan_id(None) or url(url) missing")
 
 
-@pytest.mark.asyncio
 @patch("crawler.crawler.log")
-async def test_crawl_url_missing(mock_logger):
+def test_crawl_url_missing(mock_logger):
     item = mock_item()
     item["url"] = None
-    await crawler.crawl(item)
+    crawler.crawl(item)
     mock_logger.error.assert_called_once_with("scan_id(scan_id) or url(None) missing")
 
 
-@pytest.mark.asyncio
 @patch("crawler.crawler.Process")
 @patch("crawler.crawler.runner")
-async def test_crawl_spawns_process(mock_runner, mock_process_class):
+def test_crawl_spawns_process(mock_runner, mock_process_class):
     mock_process = MagicMock()
     mock_process_class.return_value = mock_process
     item = mock_item()
-    await crawler.crawl(item)
+    crawler.crawl(item)
 
     mock_process_class.assert_called_once_with(target=mock_runner, args=(item,))
     mock_process.start.assert_called_once()


### PR DESCRIPTION
When the security headers middleware was introduced that caused the background tasks to no longer run in the background since it was being blocked by the middleware. This is due to https://github.com/encode/starlette/issues/919. Moving towards a custom middleware class that uses pure ASGIApp resolves the issue.

Using this class also fixed the issue were the middleware wasn't working well in the CI environment and needed customization in-order to run tests.

Background tasks should work as expected and an immediate response received when scans are started.