### PR TITLE
chore: disable debug logs

### DIFF
--- a/api/collector.yaml
+++ b/api/collector.yaml
@@ -6,7 +6,6 @@ receivers:
 
 exporters:
   logging:
-    loglevel: debug
   awsxray:
 
 service:
@@ -14,6 +13,3 @@ service:
     traces:
       receivers: [otlp]
       exporters: [awsxray, logging]
-  telemetry:
-    logs:
-      level: debug


### PR DESCRIPTION
Reduce logging to default levels now that opentelemetry instrumentation is working as expected.