### PR TITLE
chore: remove uvloop event loop; no longer required

### DIFF
--- a/api/crawler/crawler.py
+++ b/api/crawler/crawler.py
@@ -49,7 +49,6 @@ def runner(item):
     runner = CrawlerProcess(
         settings={
             "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
-            "ASYNCIO_EVENT_LOOP": "uvloop.Loop",
             "DOWNLOAD_HANDLERS": {
                 "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
                 "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -20,4 +20,3 @@ python-multipart==0.0.5
 SQLAlchemy==1.4.22
 scrapy==2.5.0
 scrapy-playwright==0.0.4
-uvloop==0.16.0

--- a/api/tests/crawler/test_crawler.py
+++ b/api/tests/crawler/test_crawler.py
@@ -46,7 +46,6 @@ def test_crawl_runner_calls_spider(mock_cawler_class):
     mock_cawler_class.assert_called_once_with(
         settings={
             "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
-            "ASYNCIO_EVENT_LOOP": "uvloop.Loop",
             "DOWNLOAD_HANDLERS": {
                 "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
                 "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",


### PR DESCRIPTION
Now that the background task has been fixed, the uvloop custom asyncio event loop for scrapy is no longer required since background task will automatically create a new event loop for the crawl to run in.