### PR TITLE
feat: run crawler in its own thread

### DIFF
--- a/api/crawler/crawler.py
+++ b/api/crawler/crawler.py
@@ -1,7 +1,6 @@
 import os
 import threading
 
-from asyncio import new_event_loop
 from urllib.parse import urlparse
 from multiprocessing.context import Process
 

--- a/api/crawler/crawler.py
+++ b/api/crawler/crawler.py
@@ -1,4 +1,7 @@
 import os
+import threading
+
+from asyncio import new_event_loop
 from urllib.parse import urlparse
 from multiprocessing.context import Process
 
@@ -49,6 +52,7 @@ def runner(item):
     runner = CrawlerProcess(
         settings={
             "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+            "ASYNCIO_EVENT_LOOP": "uvloop.Loop",
             "DOWNLOAD_HANDLERS": {
                 "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
                 "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
@@ -91,5 +95,6 @@ def crawl(item):
         return
 
     process = Process(target=runner, args=(item,))
-    process.start()
+    background = threading.Thread(target=process.start(), name="Crawler")
+    background.start()
     process.join()

--- a/api/database/seed.py
+++ b/api/database/seed.py
@@ -264,6 +264,15 @@ if __name__ == "__main__":
     )
     session.add(a11y_report)
 
+    empty_a11y_report = A11yReport(
+        product="product",
+        revision=str(uuid.uuid4()),
+        url="https://www.alpha.canada.ca",
+        summary={"status": "scanning"},
+        scan=axe_core_only_scan,
+    )
+    session.add(empty_a11y_report)
+
     owasp_zap_security_report_no_results = SecurityReport(
         product="product",
         revision=str(uuid.uuid4()),

--- a/api/front_end/templates/scan_results_a11y.html
+++ b/api/front_end/templates/scan_results_a11y.html
@@ -52,7 +52,7 @@
               </thead>
               <tbody class="bg-white divide-y divide-gray-200">
                 {% for a11y_report in scan.a11y_reports %}
-                  {% if 'violations' in a11y_report.summary %}
+                  
                     <tr>
                       <td class="px-6 py-4 whitespace-nowrap truncate">
                         <div class="text-sm font-medium text-gray-900">
@@ -64,6 +64,7 @@
                           {{ a11y_report.created_at.strftime('%d-%m-%Y %H:%M:%S') }}
                         </div>
                       </td>
+                      {% if 'violations' in a11y_report.summary %}
                       <td class="px-6 py-4 whitespace-nowrap">
                         <div class="text-sm font-medium text-gray-900">
                           <p class="flex flex-wrap gap-2">
@@ -74,6 +75,18 @@
                           </p>
                         </div>
                       </td>
+                      {% else %}
+                      <td class="px-6 py-4 whitespace-nowrap">
+                        <div class="text-sm font-medium text-gray-900">
+                          <p class="flex flex-wrap gap-2">
+                            <span class="{{ 'bg-gray-100'}} inline-block p-1 px-2">0&nbsp;{{ critical_locale }}</span>
+                            <span class="{{ 'bg-gray-100'}} inline-block p-1 px-2">0&nbsp;{{ serious_locale }}</span>
+                            <span class="{{ 'bg-gray-100'}} inline-block p-1 px-2">0&nbsp;{{ moderate_locale }}</span>
+                            <span class="{{ 'bg-gray-100'}} inline-block p-1 px-2">0&nbsp;{{ minor_locale }}</span>
+                          </p>
+                        </div>
+                      </td>
+                      {% endif %}
                       <td class="text-center">
                         <a href="/{{ lang }}/results/{{ scan.template.id }}/a11y/{{scan.id}}/{{ a11y_report.id }}">
                           <span class="material-icons">description</span>
@@ -95,7 +108,6 @@
                         </form>
                       </td>
                     </tr>
-                  {% endif %}
                 {% endfor %}
               </tbody>
             </table>

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -20,3 +20,4 @@ python-multipart==0.0.5
 SQLAlchemy==1.4.22
 scrapy==2.5.0
 scrapy-playwright==0.0.4
+uvloop==0.16.0

--- a/api/storage/storage.py
+++ b/api/storage/storage.py
@@ -83,9 +83,14 @@ def store_axe_core_record(session, payload):
         a11y_report.summary["violations"] = sum_impact(
             report["violations"], a11y_report.summary["violations"]
         )
-        a11y_report.summary["violations"]["total"] += sum(
-            list(summary["violations"].values())
-        )
+        if "total" in a11y_report.summary["violations"]:
+            a11y_report.summary["violations"]["total"] += sum(
+                list(summary["violations"].values())
+            )
+        else:
+            a11y_report.summary["violations"]["total"] = sum(
+                list(summary["violations"].values())
+            )
         a11y_report.summary["passes"] += len(report["passes"])
         flag_modified(a11y_report, "summary")
         session.commit()
@@ -115,7 +120,7 @@ def store_axe_core_record(session, payload):
 
 
 def sum_impact(violations, d=None):
-    if d is None:
+    if d is None or type(d) is not dict:
         d = {}
 
     for v in violations:

--- a/api/tests/crawler/test_crawler.py
+++ b/api/tests/crawler/test_crawler.py
@@ -46,6 +46,7 @@ def test_crawl_runner_calls_spider(mock_cawler_class):
     mock_cawler_class.assert_called_once_with(
         settings={
             "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+            "ASYNCIO_EVENT_LOOP": "uvloop.Loop",
             "DOWNLOAD_HANDLERS": {
                 "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
                 "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",


### PR DESCRIPTION
- Crawler occasionally blocks the main thread which will cause the scan request to timeout at the apigateway. Running the crawl in a dedicated thread should make the results more consistent.
- Minor tweaks to the a11y views so that scans that failed can be deleted. Currently only reports with results are visible, so you can't delete bad scans