### PR TITLE
feat: add TG IAM Roles for OIDC

### DIFF
--- a/terragrunt/aws/tf_roles/main.tf
+++ b/terragrunt/aws/tf_roles/main.tf
@@ -30,6 +30,11 @@ resource "aws_iam_role_policy_attachment" "readonly" {
   policy_arn = data.aws_iam_policy.readonly.arn
 }
 
+resource "aws_iam_role_policy_attachment" "readonly"{
+  role = local.plan_name
+  policy_arn = resource.aws_iam_policy.terragrunt.arn
+}
+
 data "aws_iam_policy" "admin" {
   name = "AdministratorAccess"
 }
@@ -37,4 +42,33 @@ data "aws_iam_policy" "admin" {
 resource "aws_iam_role_policy_attachment" "admin" {
   role       = local.admin_name
   policy_arn = data.aws_iam_policy.admin.arn
+}
+
+
+resource "aws_iam_policy" "terragrunt" {
+  name = "Terragrunt"
+  policy = aws_iam_policy_document.terragrunt.json
+}
+
+data "aws_iam_policy_document" "terragrunt" {
+
+  statement {
+    sid  = "AllowAllDynamoDBActionsOnAllTerragruntTables"
+    effect = "Allow"
+    action = [ "dynamodb:*" ]
+    resource = [
+      "arn:aws:dynamodb:*:1234567890:table/terraform-state-lock-dynamo"
+    ]
+  }
+
+  statement {
+    sid = "AllowAllS3ActionsOnTerragruntBuckets"
+    effect = "Allow"
+    action = ["s3:*"]
+    resource = [
+        "arn:aws:s3:::scan-websites-production-tf",
+        "arn:aws:s3:::scan-websites-production-tf/*"
+    ]
+  }
+
 }

--- a/terragrunt/aws/tf_roles/main.tf
+++ b/terragrunt/aws/tf_roles/main.tf
@@ -47,7 +47,7 @@ resource "aws_iam_role_policy_attachment" "admin" {
 
 resource "aws_iam_policy" "terragrunt" {
   name   = "Terragrunt"
-  policy = aws_iam_policy_document.terragrunt.json
+  policy = data.aws_iam_policy_document.terragrunt.json
 }
 
 data "aws_iam_policy_document" "terragrunt" {

--- a/terragrunt/aws/tf_roles/main.tf
+++ b/terragrunt/aws/tf_roles/main.tf
@@ -30,7 +30,7 @@ resource "aws_iam_role_policy_attachment" "readonly" {
   policy_arn = data.aws_iam_policy.readonly.arn
 }
 
-resource "aws_iam_role_policy_attachment" "readonly"{
+resource "aws_iam_role_policy_attachment" "terragrunt"{
   role = local.plan_name
   policy_arn = resource.aws_iam_policy.terragrunt.arn
 }

--- a/terragrunt/aws/tf_roles/main.tf
+++ b/terragrunt/aws/tf_roles/main.tf
@@ -30,8 +30,8 @@ resource "aws_iam_role_policy_attachment" "readonly" {
   policy_arn = data.aws_iam_policy.readonly.arn
 }
 
-resource "aws_iam_role_policy_attachment" "terragrunt"{
-  role = local.plan_name
+resource "aws_iam_role_policy_attachment" "terragrunt" {
+  role       = local.plan_name
   policy_arn = resource.aws_iam_policy.terragrunt.arn
 }
 
@@ -46,28 +46,28 @@ resource "aws_iam_role_policy_attachment" "admin" {
 
 
 resource "aws_iam_policy" "terragrunt" {
-  name = "Terragrunt"
+  name   = "Terragrunt"
   policy = aws_iam_policy_document.terragrunt.json
 }
 
 data "aws_iam_policy_document" "terragrunt" {
 
   statement {
-    sid  = "AllowAllDynamoDBActionsOnAllTerragruntTables"
+    sid    = "AllowAllDynamoDBActionsOnAllTerragruntTables"
     effect = "Allow"
-    action = [ "dynamodb:*" ]
+    action = ["dynamodb:*"]
     resource = [
       "arn:aws:dynamodb:*:1234567890:table/terraform-state-lock-dynamo"
     ]
   }
 
   statement {
-    sid = "AllowAllS3ActionsOnTerragruntBuckets"
+    sid    = "AllowAllS3ActionsOnTerragruntBuckets"
     effect = "Allow"
     action = ["s3:*"]
     resource = [
-        "arn:aws:s3:::scan-websites-production-tf",
-        "arn:aws:s3:::scan-websites-production-tf/*"
+      "arn:aws:s3:::scan-websites-production-tf",
+      "arn:aws:s3:::scan-websites-production-tf/*"
     ]
   }
 

--- a/terragrunt/aws/tf_roles/main.tf
+++ b/terragrunt/aws/tf_roles/main.tf
@@ -53,8 +53,8 @@ resource "aws_iam_policy" "terragrunt" {
 data "aws_iam_policy_document" "terragrunt" {
 
   statement {
-    sid    = "AllowAllDynamoDBActionsOnAllTerragruntTables"
-    effect = "Allow"
+    sid     = "AllowAllDynamoDBActionsOnAllTerragruntTables"
+    effect  = "Allow"
     actions = ["dynamodb:*"]
     resources = [
       "arn:aws:dynamodb:*:1234567890:table/terraform-state-lock-dynamo"
@@ -62,8 +62,8 @@ data "aws_iam_policy_document" "terragrunt" {
   }
 
   statement {
-    sid    = "AllowAllS3ActionsOnTerragruntBuckets"
-    effect = "Allow"
+    sid     = "AllowAllS3ActionsOnTerragruntBuckets"
+    effect  = "Allow"
     actions = ["s3:*"]
     resources = [
       "arn:aws:s3:::scan-websites-production-tf",

--- a/terragrunt/aws/tf_roles/main.tf
+++ b/terragrunt/aws/tf_roles/main.tf
@@ -55,8 +55,8 @@ data "aws_iam_policy_document" "terragrunt" {
   statement {
     sid    = "AllowAllDynamoDBActionsOnAllTerragruntTables"
     effect = "Allow"
-    action = ["dynamodb:*"]
-    resource = [
+    actions = ["dynamodb:*"]
+    resources = [
       "arn:aws:dynamodb:*:1234567890:table/terraform-state-lock-dynamo"
     ]
   }
@@ -64,8 +64,8 @@ data "aws_iam_policy_document" "terragrunt" {
   statement {
     sid    = "AllowAllS3ActionsOnTerragruntBuckets"
     effect = "Allow"
-    action = ["s3:*"]
-    resource = [
+    actions = ["s3:*"]
+    resources = [
       "arn:aws:s3:::scan-websites-production-tf",
       "arn:aws:s3:::scan-websites-production-tf/*"
     ]


### PR DESCRIPTION
# Summary | Résumé

Add roles so that the plan OIDC role can access state bucket and Lock Table.
Closes #283 
