### PR TITLE
fix: use the proper ARN for dynamodb table

### DIFF
--- a/terragrunt/aws/tf_roles/main.tf
+++ b/terragrunt/aws/tf_roles/main.tf
@@ -57,7 +57,7 @@ data "aws_iam_policy_document" "terragrunt" {
     effect  = "Allow"
     actions = ["dynamodb:*"]
     resources = [
-      "arn:aws:dynamodb:*:1234567890:table/terraform-state-lock-dynamo"
+      "arn:aws:dynamodb:ca-central-1:507252742351:table/terraform-state-lock-dynamo"
     ]
   }
 


### PR DESCRIPTION
# Summary | Résumé

Unfortunately i copied and pasted from the TG Docs and forgot to change the ARN from a generic one.
