### PR TITLE
fix: allow tf plan to read secrets

### DIFF
--- a/terragrunt/aws/tf_roles/main.tf
+++ b/terragrunt/aws/tf_roles/main.tf
@@ -71,4 +71,21 @@ data "aws_iam_policy_document" "terragrunt" {
     ]
   }
 
+  statement {
+    sid    = "AllowReadingSecrets"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetResourcePolicy",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:ListSecretVersionIds"
+    ]
+    resources = ["arn:aws:secretsmanager:ca-central-1:507252742351:secret:*"]
+  }
+
+  statement {
+    sid       = "ListSecrets"
+    actions   = ["secretsmanager:ListSecrets"]
+    resources = ["*"]
+  }
 }


### PR DESCRIPTION
# Summary | Résumé

The plan is failing on refreshing state because ReadOnlyAccess denies access to secrets (For good reason).
