### PR TITLE
fix: firehose write to s3 missing iam permissions

### DIFF
--- a/terragrunt/aws/api/api_gateway.tf
+++ b/terragrunt/aws/api/api_gateway.tf
@@ -151,9 +151,11 @@ resource "aws_api_gateway_deployment" "api" {
 
 resource "aws_api_gateway_stage" "api" {
   # checkov:skip=CKV2_AWS_29: False-positive, API stage is associated with WAF ACL in ./waf.tf
-  deployment_id = aws_api_gateway_deployment.api.id
-  rest_api_id   = aws_api_gateway_rest_api.api.id
-  stage_name    = "v1"
+  deployment_id        = aws_api_gateway_deployment.api.id
+  rest_api_id          = aws_api_gateway_rest_api.api.id
+  stage_name           = "v1"
+  xray_tracing_enabled = true
+  cache_cluster_size   = "0.5"
 
   access_log_settings {
     destination_arn = aws_cloudwatch_log_group.api_access.arn

--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -178,7 +178,7 @@ resource "aws_iam_role" "waf_log_role" {
 
 resource "aws_iam_policy" "write_waf_logs" {
   name        = "${var.product_name}_WriteLogs"
-  description = "Allow writing WAF logs to S3 + CloudWatch"
+  description = "Allow writing WAF logs to S3"
   policy      = data.aws_iam_policy_document.write_waf_logs.json
 
   tags = {
@@ -207,27 +207,19 @@ data "aws_iam_policy_document" "firehose_assume_role" {
 
 data "aws_iam_policy_document" "write_waf_logs" {
   statement {
+    sid    = "S3PutObjects"
     effect = "Allow"
-
     actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
       "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:PutObject"
     ]
-
     resources = [
-      "arn:aws:s3:::${var.cbs_satellite_bucket_name}"
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "s3:GetObject*",
-      "s3:PutObject*",
-    ]
-
-    resources = [
-      "arn:aws:s3:::${var.cbs_satellite_bucket_name}/waf_logs/*"
+      "arn:aws:s3:::${var.cbs_satellite_bucket_name}",
+      "arn:aws:s3:::${var.cbs_satellite_bucket_name}/waf_acl_logs/*"
     ]
   }
 }

--- a/terragrunt/aws/api/waf.tf
+++ b/terragrunt/aws/api/waf.tf
@@ -211,7 +211,7 @@ resource "aws_kinesis_firehose_delivery_stream" "api_waf" {
 
   extended_s3_configuration {
     role_arn   = aws_iam_role.waf_log_role.arn
-    prefix     = "waf_acl_logs"
+    prefix     = "waf_acl_logs/"
     bucket_arn = "arn:aws:s3:::${var.cbs_satellite_bucket_name}"
   }
 

--- a/terragrunt/aws/api/waf.tf
+++ b/terragrunt/aws/api/waf.tf
@@ -211,7 +211,7 @@ resource "aws_kinesis_firehose_delivery_stream" "api_waf" {
 
   extended_s3_configuration {
     role_arn   = aws_iam_role.waf_log_role.arn
-    prefix     = "waf_logs"
+    prefix     = "waf_acl_logs"
     bucket_arn = "arn:aws:s3:::${var.cbs_satellite_bucket_name}"
   }
 


### PR DESCRIPTION
Adds missing IAM policies that was preventing WAF ACL logs from being written to S3