### PR TITLE
fix: UTC time was causing inconsistent filenames

### DIFF
--- a/scanners/axe-core/package-lock.json
+++ b/scanners/axe-core/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@axe-core/puppeteer": "^4.3.1",
-        "aws-sdk": "^2.1046.0",
+        "aws-sdk": "^2.1055.0",
         "puppeteer": "^10.2.0"
       },
       "devDependencies": {
@@ -1719,14 +1719,14 @@
       "dev": true
     },
     "node_modules/aws-sdk": {
-      "version": "2.1054.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1054.0.tgz",
-      "integrity": "sha512-y8OAffen0uoKSnCZp4Nb1dDsUqOOfr+m68cL1lRW8c7g1FjugH3u7CZmAnlA7PxenZUpnSeN3yBtHqIZhkMT4w==",
+      "version": "2.1067.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1067.0.tgz",
+      "integrity": "sha512-3Ys1k4cNQy4z37IpPjQ9c5ldkXMeZGbWoarKHynPPY3WCEj+Nw2u6zk484fA9/lTHNN3YesLuZ0OmEzGgjFEOw==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
@@ -4526,9 +4526,9 @@
       }
     },
     "node_modules/jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -7864,14 +7864,14 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.1054.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1054.0.tgz",
-      "integrity": "sha512-y8OAffen0uoKSnCZp4Nb1dDsUqOOfr+m68cL1lRW8c7g1FjugH3u7CZmAnlA7PxenZUpnSeN3yBtHqIZhkMT4w==",
+      "version": "2.1067.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1067.0.tgz",
+      "integrity": "sha512-3Ys1k4cNQy4z37IpPjQ9c5ldkXMeZGbWoarKHynPPY3WCEj+Nw2u6zk484fA9/lTHNN3YesLuZ0OmEzGgjFEOw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
@@ -9960,9 +9960,9 @@
       }
     },
     "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/scanners/axe-core/package.json
+++ b/scanners/axe-core/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@axe-core/puppeteer": "^4.3.1",
-    "aws-sdk": "^2.1046.0",
+    "aws-sdk": "^2.1055.0",
     "puppeteer": "^10.2.0"
   }
 }

--- a/scanners/axe-core/src/impl.test.ts
+++ b/scanners/axe-core/src/impl.test.ts
@@ -100,7 +100,7 @@ describe("Impl", () => {
         Bucket: "screenshotBucketName",
         Body: Buffer.from("I'm a string!", "utf-8"),
         ContentType: "image/png",
-        Key: `bar_${staticDate.toJSON()}.png`,
+        Key: `bar_${staticDate.getTime()}.png`,
       });
 
       expect(storeMock.putObject).toHaveBeenCalledWith({
@@ -111,7 +111,7 @@ describe("Impl", () => {
           report: mockReport,
         }),
         ContentType: "application/json",
-        Key: `bar_${staticDate.toJSON()}.json`,
+        Key: `bar_${staticDate.getTime()}.json`,
       });
       expect(response).toBe(true);
     });
@@ -140,7 +140,7 @@ describe("Impl", () => {
         report: mockReport,
       }),
       ContentType: "application/json",
-      Key: `bar_${staticDate.toJSON()}.json`,
+      Key: `bar_${staticDate.getTime()}.json`,
     });
     expect(result).toEqual(true);
   });

--- a/scanners/axe-core/src/impl.ts
+++ b/scanners/axe-core/src/impl.ts
@@ -117,7 +117,7 @@ const createReport = async (
   await store
     .putObject({
       Bucket: reportBucket,
-      Key: `${id}_${new Date().toJSON()}.json`,
+      Key: `${id}_${new Date().getTime()}.json`,
       Body: JSON.stringify(object),
       ContentType: "application/json",
     })
@@ -141,7 +141,7 @@ const takeScreenshot = async (
   await store
     .putObject({
       Bucket: screenshotBucket,
-      Key: `${id}_${new Date().toJSON()}.png`,
+      Key: `${id}_${new Date().getTime()}.png`,
       Body: screenshot as Buffer | Uint8Array | string,
       ContentType: "image/png",
     })


### PR DESCRIPTION
S3 was automatically encoding the `:` in the UTC time of filenames, resulting in errors when the api attempts to retrieve axe-core report data. Moving from UTC time to epoch time as a unique identifier will ensure no special characters exist in filenames.

Also upgrading aws-sdk from 2.1054.0 to 2.1055.0 to resolve a Snyk reported vulnerability.