### PR TITLE
feat: don't store violations when all results ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,4 @@ dist
 
 # VSCode settings
 .vscode
+settings.json

--- a/api/storage/storage.py
+++ b/api/storage/storage.py
@@ -249,6 +249,7 @@ def store_owasp_zap_record(session, payload):
                 if len(security_violation.data) > 0:
                     session.add(security_violation)
                 else:
+                    session.expunge(security_violation)
                     summary[alert["riskdesc"]] -= int(alert["count"])
                     summary["total"] -= int(alert["count"])
 

--- a/api/tests/storage/test_storage.py
+++ b/api/tests/storage/test_storage.py
@@ -356,9 +356,9 @@ def test_store_owasp_zap_record_creates_violations_and_ignores(session):
             SecurityViolation.security_report_id == security_report.id,
             SecurityViolation.violation == first_violation["alert"],
         )
-        .one()
+        .one_or_none()
     )
-    assert len(violation.data) == 0
+    assert violation is None
 
 
 def test_filter_owasp_zap_results():


### PR DESCRIPTION
Currently OWASP Zap reports are displaying `0` results when items have been flagged as a false positive using the ignore feature and all results end up being filtered.

![image](https://user-images.githubusercontent.com/85885638/152549425-fa224943-828f-4d77-97c0-f190ce7f264c.png)

This PR will ensure violations that have had all it's items ignored will not be stored as an empty array and instead will be removed from the session so they don't get commited.
