### PR TITLE
fix: validate before referencing optional fields

### DIFF
--- a/api/front_end/templates/scan_results_nuclei_summary.html
+++ b/api/front_end/templates/scan_results_nuclei_summary.html
@@ -47,7 +47,13 @@
                                               <td class="w-5/6 align-top p-3">
                                                   {{ security_violation.data[0].description }}
                                               </td>
-                                          </tr>
+                                            </tr>
+                                            <tr class="border border-gray-300">
+                                              <th scope='row' class="bg-gray-100 p-3">{{ risk_locale }}</th>
+                                              <td class="w-5/6 align-top p-3">
+                                                  {{ security_violation.risk }}
+                                              </td>
+                                            </tr>
                                             <tr class="border border-gray-300">
                                                 <th scope='row' class="bg-gray-100 p-3">{{ curl_locale }}</th>
                                                 <td class="w-5/6 text-xs align-top truncate p-3">

--- a/api/front_end/templates/scan_results_nuclei_summary.html
+++ b/api/front_end/templates/scan_results_nuclei_summary.html
@@ -43,6 +43,12 @@
                                                 </td>
                                             </tr>
                                             <tr class="border border-gray-300">
+                                              <th scope='row' class="bg-gray-100 p-3">{{ description_locale }}</th>
+                                              <td class="w-5/6 align-top p-3">
+                                                  {{ security_violation.data[0].description }}
+                                              </td>
+                                          </tr>
+                                            <tr class="border border-gray-300">
                                                 <th scope='row' class="bg-gray-100 p-3">{{ curl_locale }}</th>
                                                 <td class="w-5/6 text-xs align-top truncate p-3">
                                                     <code class="whitespace-pre-wrap wordbreak-break-all">{{ security_violation.data[0].curl_command | escape | trim }}</code>
@@ -64,6 +70,16 @@
                                                     </ul>
                                                 </td>
                                             </tr>
+                                            <tr class="border border-gray-300">
+                                              <th scope='row' class="bg-gray-100 p-3">{{ references_locale }}</th>
+                                              <td class='w-5/6 text-xs align-top truncate p-3'>
+                                                  <ul class='flex space-x-2'>
+                                                      {% for reference in security_violation.data[0].reference %}
+                                                          <li class='p1 px-2 bg-gray-100'>{{ reference }}</li>
+                                                      {% endfor %}
+                                                  </ul>
+                                              </td>
+                                          </tr>
                                         </table>
                                     </td>
                                 </tr>

--- a/api/i18n/en.json
+++ b/api/i18n/en.json
@@ -12,6 +12,7 @@
   "curl_locale": "CURL command",
   "dashboard_locale": "Dashboard",
   "date_locale": "Date",
+  "description_locale": "Description",
   "delete_locale": "Delete",
   "edit_locale": "Edit",
   "email_locale": "Email",

--- a/api/i18n/fr.json
+++ b/api/i18n/fr.json
@@ -12,6 +12,7 @@
   "curl_locale": "Commande CURL",
   "dashboard_locale": "Tableau de bord",
   "date_locale": "Date",
+  "description_locale": "Description",
   "delete_locale": "Effacer",
   "edit_locale": "Modifier",
   "email_locale": "Courriel",

--- a/api/storage/storage.py
+++ b/api/storage/storage.py
@@ -283,19 +283,31 @@ def store_nuclei_record(session, payload):
         else:
             summary[report["info"]["severity"]] = 1
 
+        if "matcher-name" in report:
+            matcher_name = report["matcher-name"]
+        else:
+            matcher_name = ""
+
+        if "description" in report["info"]:
+            description = report["info"]["description"]
+        else:
+            description = ""
+
         summary["total"] += 1
         security_violation = SecurityViolation(
             violation=report["info"]["name"],
             risk=report["info"]["severity"],
-            message=report["matcher-name"],
+            message=report["template-id"],
             confidence=100,
             data=[
                 {
                     "uri": report["matched-at"],
                     "template_id": report["template-id"],
                     "type": report["type"],
-                    "matcher_name": report["matcher-name"],
+                    "matcher_name": matcher_name,
                     "curl_command": report["curl-command"],
+                    "description": description,
+                    "reference": report["info"]["reference"],
                 }
             ],
             tags=report["info"]["tags"],


### PR DESCRIPTION
Nuclei output has some optional outputs that are not consistent. This PR will validate before trying to store some of the optional fields.