### PR TITLE
feat: generate API and axe-core SBOM

### DIFF
--- a/.github/workflows/generate_sbom.yml
+++ b/.github/workflows/generate_sbom.yml
@@ -1,0 +1,40 @@
+name: Generate SBOM
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - api/requirements.txt
+      - scanners/axe-core/package-lock.json
+      - .github/workflows/generate_sbom.yml
+  push:
+    branches:
+      - main
+    paths:
+      - api/requirements.txt
+      - scanners/axe-core/package-lock.json      
+      - .github/workflows/generate_sbom.yml      
+
+jobs:
+  generate-api-sbom:
+    name: Generate API SBOM
+    uses: cds-snc/security-tools/.github/workflows/generate_sbom.yml@main
+    with:
+      project_name: scan-websites/api
+      project_type: python
+      project_version: main
+      working_directory: api
+    secrets:
+      dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+
+  generate-scanner-axe-core-sbom:
+    name: Generate axe-core SBOM
+    uses: cds-snc/security-tools/.github/workflows/generate_sbom.yml@main
+    with:
+      project_name: scan-websites/scanner/axe-core
+      project_type: node
+      project_version: main
+      working_directory: scanners/axe-core
+    secrets:
+      dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}      


### PR DESCRIPTION
# Summary
Add GitHub workflow to generate SBOMs for the API and
axe-core scanner.

# Related
* cds-snc/platform-sre-security-support#94