### PR TITLE
chore: upgrade postgres to 13.6

### DIFF
--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -10,5 +10,5 @@ module "rds" {
   username                = var.rds_username
   password                = var.rds_password
   vpc_id                  = module.vpc.vpc_id
-  engine_version          = "11.13"
+  engine_version          = "13.6"
 }


### PR DESCRIPTION
This PR upgrade the postrgres engine to 13.6 in which case we can add a serverless reader and switch to serverless.