### PR TITLE
chore: upgrade postgres to 13.4

### DIFF
--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -10,5 +10,5 @@ module "rds" {
   username                = var.rds_username
   password                = var.rds_password
   vpc_id                  = module.vpc.vpc_id
-  engine_version          = "13.6"
+  engine_version          = "13.4"
 }


### PR DESCRIPTION
Go to 13.4 first :( 

https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion