### PR TITLE
chore: update to latest generate-sbom action

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -93,7 +93,7 @@ jobs:
           migrate
 
       - name: Generate ${{ matrix.image }}/docker SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@b09c1aefae9876dd2a23888c50b2daaa137ba01d # tag=v1
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@14ab23f07437d642594c56003db1f4bd34e54bbb # tag=v1
         with:
           dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           docker_image: $REGISTRY/${{ matrix.image }}:$GITHUB_SHA

--- a/.github/workflows/ci_build_continers.yml
+++ b/.github/workflows/ci_build_continers.yml
@@ -70,7 +70,7 @@ jobs:
           -t $REGISTRY/${{ matrix.image }}:latest .
 
       - name: Generate ${{ matrix.image }}/docker SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@b09c1aefae9876dd2a23888c50b2daaa137ba01d # tag=v1
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@14ab23f07437d642594c56003db1f4bd34e54bbb # tag=v1
         with:
           dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           docker_image: $REGISTRY/${{ matrix.image }}:latest

--- a/.github/workflows/generate_sbom.yml
+++ b/.github/workflows/generate_sbom.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # tag=v2
 
       - name: Generate api SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@b09c1aefae9876dd2a23888c50b2daaa137ba01d # tag=v1
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@14ab23f07437d642594c56003db1f4bd34e54bbb # tag=v1
         with:
           dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           project_name: scan-websites/api
@@ -32,7 +32,7 @@ jobs:
           working_directory: api
 
       - name: Generate scanners/axe-core SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@b09c1aefae9876dd2a23888c50b2daaa137ba01d # tag=v1
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@14ab23f07437d642594c56003db1f4bd34e54bbb # tag=v1
         with:
           dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           project_name: scan-websites/scanners/axe-core


### PR DESCRIPTION
# Summary
This provides a fix for the slow `docker sbom` creation.

# Related
* cds-snc/platform-sre-security-support#94