### PR TITLE
* Add platform enforcement to support ARM chips.

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,6 +6,7 @@ x-db-connection-strings: &db-connection-strings
 
 services:
   app:
+    platform: linux/x86_64
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile


### PR DESCRIPTION
# Summary | Résumé

Closes #343

Sets the platform for the Docker Containers to amd64 so that platforms running arm64 don't try to override the platform (and thus don't work)

# Test instructions | Instructions pour tester la modification

Run Dev env on arm64 device, and it will no longer be mad about dependencies that aren't available on arm64. 
