### PR TITLE
feat: only restart services if devcontainer not stopped

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -43,7 +43,7 @@ services:
   api:
     build:
       context: ../api/
-    restart: always
+    restart: unless-stopped
     volumes:
       - ../api:/function
     environment:
@@ -72,7 +72,7 @@ services:
     image: postgres:11.16
     volumes:
       - ./initdb:/docker-entrypoint-initdb.d
-    restart: always
+    restart: unless-stopped
     command:
       - "postgres"
       - "-c"
@@ -91,7 +91,7 @@ services:
     image: postgres:11.16
     volumes:
       - ./initdb:/docker-entrypoint-initdb.d
-    restart: always
+    restart: unless-stopped
     command:
       - "postgres"
       - "-c"


### PR DESCRIPTION
Currently the api, database and test database containers remain active after the devcontainer is closed. This is due to the docker compose restart policy. Changing it to `unless-stopped` will prevent these services from being restarted when the devcontainer issues a [stop command](https://github.com/cds-snc/scan-websites/blob/5dec17f59f6a032940dcbc37bf367990d075c9e6/.devcontainer/devcontainer.json#L8)