### PR TITLE
fix: refactor for authlib v1 implementation

### DIFF
--- a/api/api_gateway/routers/auth.py
+++ b/api/api_gateway/routers/auth.py
@@ -102,7 +102,7 @@ async def auth_google(
 ):
     try:
         token = await oauth.google.authorize_access_token(request)
-        user = token['userinfo']
+        user = token["userinfo"]
         email = user["email"]
     except OAuthError as error:
         log.error(error)

--- a/api/tests/api_gateway/test_auth.py
+++ b/api/tests/api_gateway/test_auth.py
@@ -17,12 +17,14 @@ def test_google_oauth_callback(
     mock_authorize_access_token,
 ):
     fresh_client = TestClient(api.app)
-    mock_authorize_access_token.return_value = {'userinfo': UserInfo(
-        {
-            "email": "user@cds-snc.ca",
-            "name": "User McUser",
-        }
-    )}
+    mock_authorize_access_token.return_value = {
+        "userinfo": UserInfo(
+            {
+                "email": "user@cds-snc.ca",
+                "name": "User McUser",
+            }
+        )
+    }
     response = fresh_client.get("/auth/google")
 
     assert response.cookies["session"] is not None


### PR DESCRIPTION
AuthLib v1 now returns the userinfo automatically so it's no longer necessary to parse the token.