### PR TITLE
chore: upgrade RDS to postgres 14.3

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,7 +37,10 @@
         "username": "postgres",
         "password": "postgres"
       }
-    ]
+    ],
+    "[terraform]": {
+      "editor.formatOnSave": true
+    }
   },
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": [

--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -15,6 +15,14 @@ module "rds" {
   preferred_backup_window     = "07:00-09:00"
   backup_retention_period     = 1
   allow_major_version_upgrade = true
+  
+  /* 
+  When upgrade_immediately is set to TRUE there will be db downtime
+  as your db will be taken offline immediately instead of being rebuilt
+  in the next maintenance window. 
+  
+  **TAKE A SNAPSHOT BEFORE APPLYING AND BE READY TO ROLLBACK IF UPGRADE DOES NOT GO SMOOTHLY** 
+  */
   upgrade_immediately         = true
 
   serverless_min_capacity = 0.5

--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -6,7 +6,7 @@ module "rds" {
   instances      = 1
   instance_class = "db.serverless"
   engine         = "aurora-postgresql"
-  engine_version = "13.6"
+  engine_version = "14.3"
   username       = var.rds_username
   password       = var.rds_password
 
@@ -15,6 +15,7 @@ module "rds" {
   preferred_backup_window     = "07:00-09:00"
   backup_retention_period     = 1
   allow_major_version_upgrade = true
+  upgrade_immediately         = true
 
   serverless_min_capacity = 0.5
   serverless_max_capacity = 1.0

--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -15,7 +15,7 @@ module "rds" {
   preferred_backup_window     = "07:00-09:00"
   backup_retention_period     = 1
   allow_major_version_upgrade = true
-  
+
   /* 
   When upgrade_immediately is set to TRUE there will be db downtime
   as your db will be taken offline immediately instead of being rebuilt
@@ -23,7 +23,7 @@ module "rds" {
   
   **TAKE A SNAPSHOT BEFORE APPLYING AND BE READY TO ROLLBACK IF UPGRADE DOES NOT GO SMOOTHLY** 
   */
-  upgrade_immediately         = true
+  upgrade_immediately = true
 
   serverless_min_capacity = 0.5
   serverless_max_capacity = 1.0


### PR DESCRIPTION
# Summary
Upgrade RDS cluster to latest `aurora-postgresql` engine version.

Also adds a quality of life fix to the devcontainer so that Terraform code
is formatted on save.