### PR TITLE
fix: update database ACU and major version

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -26,7 +26,7 @@ resource "aws_lambda_function" "api" {
       AWS_LAMBDA_EXEC_WRAPPER             = "/opt/otel-instrument"
       OPENTELEMETRY_COLLECTOR_CONFIG_FILE = "/function/collector.yaml"
       OTEL_BSP_MAX_EXPORT_BATCH_SIZE      = 1
-      OTEL_PYTHON_ID_GENERATOR            = "aws_xray"
+      OTEL_PYTHON_ID_GENERATOR            = "xray"
       OTEL_PROPAGATORS                    = "xray"
       OTEL_EXPORTER_OTLP_ENDPOINT         = "127.0.0.1:4317"
       RERUNING_TASK_ID                    = "0"

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -26,7 +26,7 @@ resource "aws_lambda_function" "api" {
       AWS_LAMBDA_EXEC_WRAPPER             = "/opt/otel-instrument"
       OPENTELEMETRY_COLLECTOR_CONFIG_FILE = "/function/collector.yaml"
       OTEL_BSP_MAX_EXPORT_BATCH_SIZE      = 1
-      OTEL_PYTHON_ID_GENERATOR            = "xray"
+      OTEL_PYTHON_ID_GENERATOR            = "aws_xray"
       OTEL_PROPAGATORS                    = "xray"
       OTEL_EXPORTER_OTLP_ENDPOINT         = "127.0.0.1:4317"
       RERUNING_TASK_ID                    = "0"

--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -25,8 +25,8 @@ module "rds" {
   */
   upgrade_immediately = true
 
-  serverless_min_capacity = 0.5
-  serverless_max_capacity = 1.0
+  serverless_min_capacity = 1.0
+  serverless_max_capacity = 1.5
 
   billing_tag_value = var.billing_code
 }


### PR DESCRIPTION
# Summary
Update the Serverless V2 ACUs so that upgrades can be performed properly.

Also updates to Postgres `14.3`.