### PR TITLE
chore: bump serverless ACU for upgrades

### DIFF
--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -25,8 +25,8 @@ module "rds" {
   */
   upgrade_immediately = true
 
-  serverless_min_capacity = 1.0
-  serverless_max_capacity = 1.5
+  serverless_min_capacity = 4.0
+  serverless_max_capacity = 8.0
 
   billing_tag_value = var.billing_code
 }


### PR DESCRIPTION
# Summary
Increase the RDS cluster's ACU in prep for an upgrade (values recommended by AWS suppport).

Without this increase, the upgrade gets stuck in an inconsistent "upgrade" state.

# Note
- This PR should also include a `14.3` engine upgrade which previously failed to apply.
- The ACU bump was performed in the cluster to allow a minor patch update.